### PR TITLE
chore: Prometheus와 Grafana 설치 및 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
+
+    // Monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 configurations {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,12 @@ version: "3"
 
 services:
   app:
+    env_file:
+      - .env.dev
     build:
       context: .
       dockerfile: Dockerfile
     container_name: get-p-server
-    environment:
-      DB_URI: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}
     depends_on:
       - redis
       - database

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -66,3 +66,22 @@ logging:
 springdoc:
   swagger-ui:
     path: /docs
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+      base-path: ${MONITORING_URL}
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: '*'
+        include: info, health
+  endpoint:
+    prometheus:
+      enabled: true
+    info:
+      enabled: true
+    health:
+      enabled: true


### PR DESCRIPTION
## ✨ 구현한 기능
이번에 수소에 배포하면서 모니터링 도구가 있으면 좋을 것 같아 Prometheus와 Grafana를 설치 및 설정 완료 했습니다. 이제 [https://h.princip.es/get-p/monitor](https://h.princip.es/get-p/monitor)에 접속하면 현재 애플리케이션에 대한 모니터링이 가능합니다. 자세한 사용 방법은 나중에 미팅때 알려드릴게요!

## 📢 논의하고 싶은 내용
없음

## 🎸 기타
없음