### PR TITLE
chore: 테스트 속도 개선을 위해 JUnit 병렬 실행 단위를 클래스로 설정

### DIFF
--- a/src/main/java/es/princip/getp/domain/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/es/princip/getp/domain/auth/repository/EmailVerificationRepository.java
@@ -1,8 +1,8 @@
 package es.princip.getp.domain.auth.repository;
 
-import org.springframework.data.repository.CrudRepository;
 import es.princip.getp.domain.auth.domain.entity.EmailVerification;
+import org.springframework.data.keyvalue.repository.KeyValueRepository;
 
-public interface EmailVerificationRepository extends CrudRepository<EmailVerification, String> {
+public interface EmailVerificationRepository extends KeyValueRepository<EmailVerification, String> {
 
 }

--- a/src/main/java/es/princip/getp/domain/auth/repository/TokenVerificationRepository.java
+++ b/src/main/java/es/princip/getp/domain/auth/repository/TokenVerificationRepository.java
@@ -1,8 +1,8 @@
 package es.princip.getp.domain.auth.repository;
 
 import es.princip.getp.domain.auth.domain.entity.TokenVerification;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.keyvalue.repository.KeyValueRepository;
 
-public interface TokenVerificationRepository extends CrudRepository<TokenVerification, Long> {
+public interface TokenVerificationRepository extends KeyValueRepository<TokenVerification, Long> {
     boolean existsByRefreshToken(String refreshToken);
 }

--- a/src/main/java/es/princip/getp/global/config/RedisConfig.java
+++ b/src/main/java/es/princip/getp/global/config/RedisConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
 public class RedisConfig {
@@ -26,12 +25,5 @@ public class RedisConfig {
         redisConfiguration.setPort(port);
         redisConfiguration.setPassword(password);
         return new LettuceConnectionFactory(redisConfiguration);
-    }
-
-    @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        return redisTemplate;
     }
 }

--- a/src/main/resources/junit-platform.properties
+++ b/src/main/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.config.dynamic.factor=1


### PR DESCRIPTION
## ✨ 구현한 기능
- 테스트 속도 개선을 위해 JUnit이 클래스 단위로 병렬 실행되도록 설정 했습니다. 제 로컬 환경 기준 빌드 시간이 35초에서 23초로 단축 되었습니다.

## 📢 논의하고 싶은 내용
- 현재 Spring이 실행되면서 Spring Data Redis가 repository를 스캔하면서 Redis repository와 JPA repository를 안전하게 식별하지 못하는 문제가 있습니다. 에러가 발생하진 않지만, 매번 실행 시 경고문이 출력되기 때문에 수정을 하는 것이 좋아 보입니다.

## 🎸 기타
- 