### PR TITLE
GETP-114 feat: 프로젝트 좋아요 기능 구현

### DIFF
--- a/src/main/java/es/princip/getp/domain/client/domain/entity/Client.java
+++ b/src/main/java/es/princip/getp/domain/client/domain/entity/Client.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -51,6 +52,7 @@ public class Client extends BaseTimeEntity {
     private BankAccount bankAccount;
 
     @OneToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder

--- a/src/main/java/es/princip/getp/domain/people/domain/entity/People.java
+++ b/src/main/java/es/princip/getp/domain/people/domain/entity/People.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -47,13 +48,15 @@ public class People extends BaseTimeEntity {
     private String profileImageUri;
 
     @OneToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @OneToOne(mappedBy = "people")
     private PeopleProfile peopleProfile;
 
     @Builder
-    public People(final String nickname,
+    public People(
+        final String nickname,
         final String email,
         final String phoneNumber,
         final PeopleType peopleType,

--- a/src/main/java/es/princip/getp/domain/project/controller/ProjectLikeController.java
+++ b/src/main/java/es/princip/getp/domain/project/controller/ProjectLikeController.java
@@ -1,0 +1,40 @@
+package es.princip.getp.domain.project.controller;
+
+import es.princip.getp.domain.project.service.ProjectLikeService;
+import es.princip.getp.global.security.details.PrincipalDetails;
+import es.princip.getp.global.util.ApiResponse;
+import es.princip.getp.global.util.ApiResponse.ApiSuccessResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/projects")
+@RequiredArgsConstructor
+public class ProjectLikeController {
+
+    private final ProjectLikeService projectLikeService;
+
+    /**
+     * 프로젝트 좋아요
+     *
+     * @param projectId        좋아요를 누를 프로젝트 ID
+     * @param principalDetails 로그인한 사용자 정보
+     */
+    @PostMapping("/{projectId}/likes")
+    @PreAuthorize("hasRole('PEOPLE') and isAuthenticated()")
+    public ResponseEntity<ApiSuccessResult<?>> like(
+        @PathVariable Long projectId,
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        projectLikeService.like(projectId, principalDetails.getMember().getMemberId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(HttpStatus.CREATED));
+    }
+}

--- a/src/main/java/es/princip/getp/domain/project/domain/entity/ProjectLike.java
+++ b/src/main/java/es/princip/getp/domain/project/domain/entity/ProjectLike.java
@@ -1,0 +1,42 @@
+package es.princip.getp.domain.project.domain.entity;
+
+import es.princip.getp.domain.people.domain.entity.People;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "project_like")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "project_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "people_id")
+    private People people;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @Builder
+    public ProjectLike(People people, Project project) {
+        this.people = people;
+        this.project = project;
+    }
+}

--- a/src/main/java/es/princip/getp/domain/project/exception/ProjectLikeErrorCode.java
+++ b/src/main/java/es/princip/getp/domain/project/exception/ProjectLikeErrorCode.java
@@ -1,0 +1,25 @@
+package es.princip.getp.domain.project.exception;
+
+import es.princip.getp.global.exception.ErrorCode;
+import es.princip.getp.global.exception.ErrorDescription;
+import org.springframework.http.HttpStatus;
+
+public enum ProjectLikeErrorCode implements ErrorCode {
+    ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 프로젝트입니다.");
+
+    private final HttpStatus status;
+    private final ErrorDescription description;
+
+    ProjectLikeErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.description = ErrorDescription.of(this.name(), message);
+    }
+
+    public HttpStatus status() {
+        return status;
+    }
+
+    public ErrorDescription description() {
+        return description;
+    }
+}

--- a/src/main/java/es/princip/getp/domain/project/repository/ProjectLikeRepository.java
+++ b/src/main/java/es/princip/getp/domain/project/repository/ProjectLikeRepository.java
@@ -1,0 +1,9 @@
+package es.princip.getp.domain.project.repository;
+
+import es.princip.getp.domain.project.domain.entity.ProjectLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectLikeRepository extends JpaRepository<ProjectLike, Long> {
+
+    boolean existsByPeople_PeopleIdAndProject_ProjectId(Long peopleId, Long projectId);
+}

--- a/src/main/java/es/princip/getp/domain/project/service/ProjectLikeService.java
+++ b/src/main/java/es/princip/getp/domain/project/service/ProjectLikeService.java
@@ -1,0 +1,41 @@
+package es.princip.getp.domain.project.service;
+
+import es.princip.getp.domain.people.domain.entity.People;
+import es.princip.getp.domain.people.service.PeopleService;
+import es.princip.getp.domain.project.domain.entity.Project;
+import es.princip.getp.domain.project.domain.entity.ProjectLike;
+import es.princip.getp.domain.project.exception.ProjectLikeErrorCode;
+import es.princip.getp.domain.project.repository.ProjectLikeRepository;
+import es.princip.getp.global.exception.BusinessLogicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProjectLikeService {
+
+    private final ProjectService projectService;
+    private final PeopleService peopleService;
+    private final ProjectLikeRepository projectLikeRepository;
+
+    private void checkProjectIsAlreadyLiked(Long peopleId, Long projectId) {
+        if (projectLikeRepository.existsByPeople_PeopleIdAndProject_ProjectId(peopleId, projectId)) {
+            throw new BusinessLogicException(ProjectLikeErrorCode.ALREADY_LIKED);
+        }
+    }
+
+    @Transactional
+    public void like(Long memberId, Long projectId) {
+        People people = peopleService.getByMemberId(memberId);
+        Project project = projectService.getByProjectId(projectId);
+        checkProjectIsAlreadyLiked(people.getPeopleId(), projectId);
+        projectLikeRepository.save(
+            ProjectLike.builder()
+                .people(people)
+                .project(project)
+                .build()
+        );
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/controller/ProjectLikeControllerTest.java
+++ b/src/test/java/es/princip/getp/domain/project/controller/ProjectLikeControllerTest.java
@@ -1,0 +1,95 @@
+package es.princip.getp.domain.project.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import es.princip.getp.domain.member.domain.enums.MemberType;
+import es.princip.getp.domain.project.exception.ProjectErrorCode;
+import es.princip.getp.domain.project.exception.ProjectLikeErrorCode;
+import es.princip.getp.domain.project.service.ProjectLikeService;
+import es.princip.getp.global.config.SecurityConfig;
+import es.princip.getp.global.config.SecurityTestConfig;
+import es.princip.getp.global.exception.BusinessLogicException;
+import es.princip.getp.global.mock.PrincipalDetailsParameterResolver;
+import es.princip.getp.global.mock.WithCustomMockUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ProjectLikeController.class)
+@Import({SecurityConfig.class, SecurityTestConfig.class})
+@ActiveProfiles("test")
+@ExtendWith(PrincipalDetailsParameterResolver.class)
+@RequiredArgsConstructor
+@Slf4j
+public class ProjectLikeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProjectLikeService projectLikeService;
+
+    @Nested
+    class Like {
+
+        private final Long projectId = 1L;
+
+        @DisplayName("피플은 프로젝트에 좋아요를 누를 수 있다.")
+        @WithCustomMockUser(memberType = MemberType.ROLE_PEOPLE)
+        @Test
+        void like() throws Exception {
+            willDoNothing().given(projectLikeService).like(any(), any());
+
+            mockMvc.perform(post("/projects/{projectId}/likes", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+        }
+
+        @DisplayName("이미 좋아요를 누른 프로젝트에 다시 좋아요를 누를 수 없다.")
+        @WithCustomMockUser(memberType = MemberType.ROLE_PEOPLE)
+        @Test
+        void like_WhenProjectIsAlreadyLiked_ShouldBeFailed() throws Exception {
+            willThrow(new BusinessLogicException(ProjectLikeErrorCode.ALREADY_LIKED))
+                .given(projectLikeService).like(any(), any());
+
+            mockMvc.perform(post("/projects/{projectId}/likes", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict());
+        }
+
+        @DisplayName("의뢰자는 프로젝트에 좋아요를 누를 수 없다.")
+        @WithCustomMockUser(memberType = MemberType.ROLE_CLIENT)
+        @Test
+        void like_WhenMemberTypeIsClient_ShouldBeFailed() throws Exception {
+            mockMvc.perform(post("/projects/{projectId}/likes", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+        }
+
+        @DisplayName("존재하지 않는 프로젝트에 좋아요를 누를 수 없다.")
+        @WithCustomMockUser(memberType = MemberType.ROLE_PEOPLE)
+        @Test
+        void like_WhenProjectIsNotFound_ShouldBeFailed() throws Exception {
+            willThrow(new BusinessLogicException(ProjectErrorCode.PROJECT_NOT_FOUND))
+                .given(projectLikeService).like(any(), any());
+
+            mockMvc.perform(post("/projects/{projectId}/likes", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+        }
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/repository/ProjectLikeRepositoryTest.java
+++ b/src/test/java/es/princip/getp/domain/project/repository/ProjectLikeRepositoryTest.java
@@ -1,0 +1,94 @@
+package es.princip.getp.domain.project.repository;
+
+import static es.princip.getp.domain.member.domain.enums.MemberType.ROLE_CLIENT;
+import static es.princip.getp.domain.member.domain.enums.MemberType.ROLE_PEOPLE;
+import static es.princip.getp.fixture.ClientFixture.createClient;
+import static es.princip.getp.fixture.MemberFixture.createMember;
+import static es.princip.getp.fixture.PeopleFixture.createPeople;
+import static es.princip.getp.fixture.ProjectFixture.createProject;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import es.princip.getp.domain.client.domain.entity.Client;
+import es.princip.getp.domain.client.repository.ClientRepository;
+import es.princip.getp.domain.member.domain.entity.Member;
+import es.princip.getp.domain.member.repository.MemberRepository;
+import es.princip.getp.domain.people.domain.entity.People;
+import es.princip.getp.domain.people.repository.PeopleRepository;
+import es.princip.getp.domain.project.domain.entity.Project;
+import es.princip.getp.domain.project.domain.entity.ProjectLike;
+import es.princip.getp.global.config.QueryDslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(QueryDslTestConfig.class)
+class ProjectLikeRepositoryTest {
+
+    @Autowired
+    private ProjectLikeRepository projectLikeRepository;
+
+    @Autowired
+    private ClientRepository clientRepository;
+
+    @Autowired
+    private PeopleRepository peopleRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("existsByPeople_PeopleIdAndProject_ProjectId()는")
+    class ExistsByPeople_PeopleIdAndProject_ProjectId {
+
+        private final Member peopleMember = createMember("test1@example.com", ROLE_PEOPLE);
+        private final People people = createPeople(peopleMember);
+        private final Member clientMember = createMember("test2@example.com", ROLE_CLIENT);
+        private final Client client = createClient(clientMember);
+        private final Project project = createProject(client);
+
+        @BeforeEach
+        void setUp() {
+            memberRepository.save(peopleMember);
+            peopleRepository.save(people);
+            memberRepository.save(clientMember);
+            clientRepository.save(client);
+            projectRepository.save(project);
+        }
+
+        @DisplayName("회원이 해당 프로젝트에 이미 좋아요를 눌렀으면 true를 반환한다.")
+        @Test
+        void existsByMemberAndProject_ProjectId() {
+            ProjectLike projectLike = ProjectLike.builder()
+                .people(people)
+                .project(project)
+                .build();
+            projectLikeRepository.save(projectLike);
+
+            boolean exists = projectLikeRepository.existsByPeople_PeopleIdAndProject_ProjectId(
+                people.getPeopleId(), project.getProjectId()
+            );
+            assertThat(exists).isTrue();
+        }
+
+        @DisplayName("회원이 해당 프로젝트에 좋아요를 누른적이 없으면 false를 반환한다.")
+        @Test
+        void existsByMemberAndProject_ProjectId_When() {
+            boolean exists = projectLikeRepository.existsByPeople_PeopleIdAndProject_ProjectId(
+                people.getPeopleId(), project.getProjectId()
+            );
+            assertThat(exists).isFalse();
+        }
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/service/ProjectLikeServiceTest.java
+++ b/src/test/java/es/princip/getp/domain/project/service/ProjectLikeServiceTest.java
@@ -1,0 +1,99 @@
+package es.princip.getp.domain.project.service;
+
+import static es.princip.getp.fixture.MemberFixture.createMember;
+import static es.princip.getp.fixture.PeopleFixture.createPeople;
+import static es.princip.getp.fixture.ProjectFixture.createProject;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import es.princip.getp.domain.member.domain.entity.Member;
+import es.princip.getp.domain.people.domain.entity.People;
+import es.princip.getp.domain.people.service.PeopleService;
+import es.princip.getp.domain.project.domain.entity.Project;
+import es.princip.getp.domain.project.exception.ProjectErrorCode;
+import es.princip.getp.domain.project.exception.ProjectLikeErrorCode;
+import es.princip.getp.domain.project.repository.ProjectLikeRepository;
+import es.princip.getp.global.exception.BusinessLogicException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectLikeServiceTest {
+
+    @InjectMocks
+    private ProjectLikeService projectLikeService;
+
+    @Mock
+    private ProjectService projectService;
+
+    @Mock
+    private PeopleService peopleService;
+
+    @Mock
+    private ProjectLikeRepository projectLikeRepository;
+
+    @Nested
+    @DisplayName("like()는")
+    class Like {
+
+        private final Long memberId = 1L;
+        private final Long projectId = 1L;
+        private final Member member = createMember();
+
+        private final People people = createPeople(member);
+        private final Project project = createProject();
+
+        @DisplayName("프로젝트에 좋아요를 누른다.")
+        @Test
+        void like() {
+            given(projectService.getByProjectId(projectId)).willReturn(project);
+            given(peopleService.getByMemberId(memberId)).willReturn(people);
+            given(projectLikeRepository.existsByPeople_PeopleIdAndProject_ProjectId(
+                any(), any()
+            )).willReturn(false);
+
+            projectLikeService.like(memberId, projectId);
+
+            verify(projectLikeRepository, times(1)).save(any());
+        }
+
+        @DisplayName("프로젝트에 이미 좋아요가 눌러진 경우 예외를 던진다.")
+        @Test
+        void like_WhenProjectIsAlreadyLiked_ShouldThrowException() {
+            given(projectService.getByProjectId(projectId)).willReturn(project);
+            given(peopleService.getByMemberId(memberId)).willReturn(people);
+            given(projectLikeRepository.existsByPeople_PeopleIdAndProject_ProjectId(
+                any(), any()
+            )).willReturn(true);
+
+            BusinessLogicException exception =
+                catchThrowableOfType(() -> projectLikeService.like(memberId, projectId),
+                    BusinessLogicException.class);
+            assertThat(exception.getErrorCode()).isEqualTo(ProjectLikeErrorCode.ALREADY_LIKED);
+        }
+
+        @DisplayName("좋아요를 누를 프로젝트가 존재하지 않는 경우 예외를 던진다.")
+        @Test
+        void like_WhenProjectIsNotFound_ShouldThrowException() {
+            given(peopleService.getByMemberId(memberId))
+                .willReturn(people);
+            given(projectService.getByProjectId(projectId)).willThrow(
+                new BusinessLogicException(ProjectErrorCode.PROJECT_NOT_FOUND)
+            );
+
+            BusinessLogicException exception =
+                catchThrowableOfType(() -> projectLikeService.like(memberId, projectId),
+                    BusinessLogicException.class);
+            assertThat(exception.getErrorCode()).isEqualTo(ProjectErrorCode.PROJECT_NOT_FOUND);
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 구현한 기능
- 피플이 관심있는 프로젝트에 좋아요를 누를 수 있는 기능을 구현했습니다.

## 📢 논의하고 싶은 내용
- 좋아요를 누른 프로젝트 목록을 보는 API의 엔드 포인트가 고민입니다. 원래는 `Member` 엔티티에 `mappedBy`를 하려고 했는데 `People` 엔티티에 `mappedBy`를 걸게 돼서 살짝 고민이네요. 현재 생각했을 때 가장 좋은건 `GET /projects?liked=true`인 것 같아요. 다른 의견 있으시면 알려주세요!

## 🎸 기타
- 