### PR TITLE
feat: 이메일 인증, Access Token, Refresh Token의 만료 시간을 configuration 가능하게 변경

### DIFF
--- a/src/main/java/es/princip/getp/domain/auth/domain/entity/EmailVerification.java
+++ b/src/main/java/es/princip/getp/domain/auth/domain/entity/EmailVerification.java
@@ -1,12 +1,13 @@
 package es.princip.getp.domain.auth.domain.entity;
 
-import java.time.LocalDateTime;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 @Getter
 @RedisHash(value = "email_verification")
@@ -19,14 +20,14 @@ public class EmailVerification {
 
     private LocalDateTime createdAt;
 
-    @TimeToLive(unit = TimeUnit.MINUTES)
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private Long expiration;
 
-    public EmailVerification(String email, String verificationCode) {
+    public EmailVerification(String email, String verificationCode, Long expiration) {
         this.email = email;
         this.verificationCode = verificationCode;
         this.createdAt = LocalDateTime.now();
-        this.expiration = 5L;
+        this.expiration = expiration;
     }
 
     public boolean verify(String verificationCode) {

--- a/src/main/java/es/princip/getp/domain/auth/domain/entity/TokenVerification.java
+++ b/src/main/java/es/princip/getp/domain/auth/domain/entity/TokenVerification.java
@@ -1,6 +1,5 @@
 package es.princip.getp.domain.auth.domain.entity;
 
-import es.princip.getp.global.security.provider.JwtTokenProvider;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
@@ -18,12 +17,12 @@ public class TokenVerification {
     @Indexed
     private String refreshToken;
 
-    @TimeToLive(unit = TimeUnit.MINUTES)
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private Long expiration;
 
-    public TokenVerification(Long memberId, String refreshToken) {
+    public TokenVerification(Long memberId, String refreshToken, Long expiration) {
         this.memberId = memberId;
         this.refreshToken = refreshToken;
-        this.expiration = JwtTokenProvider.getREFRESH_TOKEN_EXPIRE_TIME();
+        this.expiration = expiration;
     }
 }

--- a/src/main/java/es/princip/getp/domain/auth/service/AuthService.java
+++ b/src/main/java/es/princip/getp/domain/auth/service/AuthService.java
@@ -1,21 +1,22 @@
 package es.princip.getp.domain.auth.service;
 
 import es.princip.getp.domain.auth.domain.entity.TokenVerification;
+import es.princip.getp.domain.auth.dto.request.LoginRequest;
+import es.princip.getp.domain.auth.dto.response.Token;
 import es.princip.getp.domain.auth.exception.TokenErrorCode;
 import es.princip.getp.domain.auth.repository.TokenVerificationRepository;
 import es.princip.getp.domain.member.service.MemberService;
 import es.princip.getp.global.exception.BusinessLogicException;
 import es.princip.getp.global.security.details.PrincipalDetails;
-import es.princip.getp.domain.auth.dto.request.LoginRequest;
-import es.princip.getp.domain.auth.dto.response.Token;
 import es.princip.getp.global.security.provider.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +26,9 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberService memberService;
     private final TokenVerificationRepository tokenVerificationRepository;
+
+    @Value("${spring.jwt.refresh-token.expire-time}")
+    private Long REFRESH_TOKEN_EXPIRE_TIME;
     
     public Token login(LoginRequest request) {
         String email = request.email();
@@ -63,6 +67,6 @@ public class AuthService {
     }
 
     private void cacheRefreshToken(Long memberId, String refreshToken) {
-        tokenVerificationRepository.save(new TokenVerification(memberId, refreshToken));
+        tokenVerificationRepository.save(new TokenVerification(memberId, refreshToken, REFRESH_TOKEN_EXPIRE_TIME));
     }
 }

--- a/src/main/java/es/princip/getp/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/es/princip/getp/domain/auth/service/EmailVerificationService.java
@@ -5,21 +5,33 @@ import es.princip.getp.domain.auth.exception.EmailVerificationErrorCode;
 import es.princip.getp.domain.auth.repository.EmailVerificationRepository;
 import es.princip.getp.global.exception.BusinessLogicException;
 import es.princip.getp.global.util.RandomUtil;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-@RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
 public class EmailVerificationService {
 
-    private static final int VERIFICATION_CODE_LENGTH = 4;
-
     private final EmailService emailService;
     private final EmailVerificationRepository emailVerificationRepository;
+
+    private final Long EXPIRATION_TIME;
+    private final Integer VERIFICATION_CODE_LENGTH;
+
+    public EmailVerificationService(
+        EmailService emailService,
+        EmailVerificationRepository emailVerificationRepository,
+        @Value("${spring.verification-code.expire-time}") Long EXPIRATION_TIME,
+        @Value("${spring.verification-code.length}") Integer VERIFICATION_CODE_LENGTH
+    ) {
+        this.emailService = emailService;
+        this.emailVerificationRepository = emailVerificationRepository;
+        this.EXPIRATION_TIME = EXPIRATION_TIME;
+        this.VERIFICATION_CODE_LENGTH = VERIFICATION_CODE_LENGTH;
+    }
 
     public Optional<EmailVerification> getByEmail(String email) {
         return emailVerificationRepository.findById(email);
@@ -32,7 +44,7 @@ public class EmailVerificationService {
         }
         String verificationCode = RandomUtil.generateRandomCode(VERIFICATION_CODE_LENGTH);
         emailService.sendEmail(email, "GET-P 인증 번호", verificationCode);
-        EmailVerification emailVerification = new EmailVerification(email, verificationCode);
+        EmailVerification emailVerification = new EmailVerification(email, verificationCode, EXPIRATION_TIME);
         emailVerificationRepository.save(emailVerification);
     }
 

--- a/src/main/java/es/princip/getp/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/es/princip/getp/global/security/provider/JwtTokenProvider.java
@@ -1,41 +1,40 @@
 package es.princip.getp.global.security.provider;
 
-import java.security.Key;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.stream.Collectors;
+import es.princip.getp.domain.auth.dto.response.Token;
+import es.princip.getp.domain.member.domain.entity.Member;
+import es.princip.getp.domain.member.service.MemberService;
+import es.princip.getp.global.security.details.PrincipalDetails;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
-import es.princip.getp.domain.auth.dto.response.Token;
-import es.princip.getp.domain.member.domain.entity.Member;
-import es.princip.getp.domain.member.service.MemberService;
-import es.princip.getp.global.security.details.PrincipalDetails;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 public class JwtTokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;
-  
+
+    @Value("${spring.jwt.access-token.expire-time}")
+    private Long ACCESS_TOKEN_EXPIRE_TIME;
+
+    @Value("${spring.jwt.refresh-token.expire-time}")
     @Getter
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;
+    private Long REFRESH_TOKEN_EXPIRE_TIME;
 
     private final Key key;
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,12 +35,16 @@ spring:
           timeout: 5000
           writetimeout: 5000
 
-  verification:
-    code:
-      expiration: 1800 # 초 단위
+  verification-code:
+    length: ${VERIFICATION_CODE_LENGTH}
+    expire-time: ${VERIFICATION_CODE_EXPIRATION}
   
   jwt:
     secret: ${JWT_SECRET}
+    access-token:
+      expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME}
+    refresh-token:
+      expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME}
 
   data:
     redis:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show-sql: true
@@ -35,12 +35,16 @@ spring:
           timeout: 5000
           writetimeout: 5000
 
-  verification:
-    code:
-      expiration: 1800 # 초 단위
+  verification-code:
+    length: ${VERIFICATION_CODE_LENGTH}
+    expire-time: ${VERIFICATION_CODE_EXPIRATION}
 
   jwt:
     secret: ${JWT_SECRET}
+    access-token:
+      expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME}
+    refresh-token:
+      expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME}
 
   data:
     redis:

--- a/src/test/java/es/princip/getp/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/es/princip/getp/domain/auth/service/EmailVerificationServiceTest.java
@@ -1,19 +1,10 @@
 package es.princip.getp.domain.auth.service;
 
-import static es.princip.getp.fixture.EmailVerificationFixture.createEmailVerification;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import es.princip.getp.domain.auth.domain.entity.EmailVerification;
 import es.princip.getp.domain.auth.exception.EmailVerificationErrorCode;
 import es.princip.getp.domain.auth.repository.EmailVerificationRepository;
 import es.princip.getp.global.exception.BusinessLogicException;
-import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,6 +12,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static es.princip.getp.fixture.EmailVerificationFixture.createEmailVerification;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class EmailVerificationServiceTest {
@@ -32,6 +32,16 @@ class EmailVerificationServiceTest {
 
     @InjectMocks
     private EmailVerificationService emailVerificationService;
+
+    @BeforeEach
+    void beforeAll() {
+        emailVerificationService = new EmailVerificationService(
+            emailService,
+            emailVerificationRepository,
+            1000L,
+            4
+        );
+    }
 
     @Nested
     @DisplayName("sendVerificationCode()는")

--- a/src/test/java/es/princip/getp/fixture/EmailVerificationFixture.java
+++ b/src/test/java/es/princip/getp/fixture/EmailVerificationFixture.java
@@ -4,6 +4,6 @@ import es.princip.getp.domain.auth.domain.entity.EmailVerification;
 
 public class EmailVerificationFixture {
     public static EmailVerification createEmailVerification(String email, String verificationCode) {
-        return new EmailVerification(email, verificationCode);
+        return new EmailVerification(email, verificationCode, 1000L);
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,12 +35,16 @@ spring:
           timeout: 5000
           writetimeout: 5000
 
-  verification:
-    code:
-      expiration: 1800 # 초 단위
+  verification-code:
+    length: ${VERIFICATION_CODE_LENGTH}
+    expire-time: ${VERIFICATION_CODE_EXPIRATION}
 
   jwt:
     secret: ${JWT_SECRET}
+    access-token:
+      expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME}
+    refresh-token:
+      expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME}
 
   messages:
     basename: messages/validation, messages/error


### PR DESCRIPTION
## ✨ 구현한 기능
- 개발 환경 및 스테이징 환경에서 테스트를 손쉽게 하기 위해 이메일 인증, Access Token, Refresh Token의 만료 시간을 configuration 가능하게 변경

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 