### PR TITLE
feat: 내 사용자 정보 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ local.sh
 
 # JUnit settings
 .run/
+
+src/main/resources/static/*

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -20,3 +20,8 @@ include::{docdir}/signup.adoc[]
 
 === Access Token 및 Refresh Token 재발급
 
+
+== 사용자
+
+=== 내 사용자 정보 조회
+include::{docdir}/member.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,0 +1,1 @@
+operation::/get-my-member/get-my-member[snippets="http-request,http-response,response-fields-data"]

--- a/src/main/java/es/princip/getp/domain/auth/service/SignUpService.java
+++ b/src/main/java/es/princip/getp/domain/auth/service/SignUpService.java
@@ -19,6 +19,7 @@ public class SignUpService {
     private final MemberService memberService;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
     public void sendEmailVerificationCodeForSignUp(String email) {
         if (memberService.existsByEmail(email)) {
             throw new BusinessLogicException(SignUpErrorCode.DUPLICATED_EMAIL);

--- a/src/main/java/es/princip/getp/domain/base/BaseTimeEntity.java
+++ b/src/main/java/es/princip/getp/domain/base/BaseTimeEntity.java
@@ -1,13 +1,14 @@
 package es.princip.getp.domain.base;
 
-import java.time.LocalDateTime;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
@@ -15,9 +16,9 @@ import lombok.Getter;
 public abstract class BaseTimeEntity {
     @CreatedDate
     @Column(columnDefinition = "TIMESTAMP")
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(columnDefinition = "TIMESTAMP")
-    private LocalDateTime updateAt;
+    protected LocalDateTime updatedAt;
 }

--- a/src/main/java/es/princip/getp/domain/client/dto/response/ClientResponse.java
+++ b/src/main/java/es/princip/getp/domain/client/dto/response/ClientResponse.java
@@ -3,6 +3,7 @@ package es.princip.getp.domain.client.dto.response;
 import es.princip.getp.domain.client.domain.entity.Client;
 import es.princip.getp.global.domain.values.Address;
 import es.princip.getp.global.domain.values.BankAccount;
+
 import java.time.LocalDateTime;
 
 public record ClientResponse(
@@ -26,6 +27,6 @@ public record ClientResponse(
             client.getAddress(),
             client.getBankAccount(),
             client.getCreatedAt(),
-            client.getUpdateAt());
+            client.getUpdatedAt());
     }
 }

--- a/src/main/java/es/princip/getp/domain/member/controller/MemberController.java
+++ b/src/main/java/es/princip/getp/domain/member/controller/MemberController.java
@@ -1,0 +1,43 @@
+package es.princip.getp.domain.member.controller;
+
+import es.princip.getp.domain.client.service.ClientService;
+import es.princip.getp.domain.member.domain.entity.Member;
+import es.princip.getp.domain.member.domain.enums.MemberType;
+import es.princip.getp.domain.member.dto.response.MemberResponse;
+import es.princip.getp.domain.people.service.PeopleService;
+import es.princip.getp.global.security.details.PrincipalDetails;
+import es.princip.getp.global.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static es.princip.getp.global.util.ApiResponse.ApiSuccessResult;
+
+@RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final PeopleService peopleService;
+    private final ClientService clientService;
+
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiSuccessResult<MemberResponse>> getMyMember(
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        Member member = principalDetails.getMember();
+        Long memberId = member.getMemberId();
+        String email = member.getEmail();
+        MemberType memberType = member.getMemberType();
+        String nickname = memberType.isClient() ? clientService.getByMemberId(memberId).getNickname() :
+                          memberType.isPeople() ? peopleService.getByMemberId(memberId).getNickname() :
+                          email.substring(0, email.indexOf('@'));
+        return ResponseEntity.ok().body(ApiResponse.success(HttpStatus.OK, MemberResponse.of(member, nickname)));
+    }
+}

--- a/src/main/java/es/princip/getp/domain/member/domain/entity/Member.java
+++ b/src/main/java/es/princip/getp/domain/member/domain/entity/Member.java
@@ -4,23 +4,15 @@ import es.princip.getp.domain.base.BaseTimeEntity;
 import es.princip.getp.domain.member.domain.enums.MemberType;
 import es.princip.getp.domain.member.dto.request.CreateMemberRequest;
 import es.princip.getp.domain.serviceTerm.domain.entity.ServiceTermAgreement;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -47,10 +39,20 @@ public class Member extends BaseTimeEntity {
     private List<ServiceTermAgreement> serviceTermAgreements = new ArrayList<>();
 
     @Builder
-    public Member(String email, String password, MemberType memberType) {
+    public Member(
+        Long memberId,
+        String email,
+        String password,
+        MemberType memberType,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+    ) {
+        this.memberId = memberId;
         this.email = email;
         this.password = password;
         this.memberType = memberType;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 
     public static Member from(CreateMemberRequest request) {

--- a/src/main/java/es/princip/getp/domain/member/domain/enums/MemberType.java
+++ b/src/main/java/es/princip/getp/domain/member/domain/enums/MemberType.java
@@ -1,6 +1,7 @@
 package es.princip.getp.domain.member.domain.enums;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.util.stream.Stream;
 
 public enum MemberType {
@@ -12,5 +13,13 @@ public enum MemberType {
             .filter(memberType -> memberType.toString().equals(inputValue.toUpperCase()))
             .findFirst()
             .orElse(null);
+    }
+
+    public boolean isClient() {
+        return this == ROLE_CLIENT;
+    }
+
+    public boolean isPeople() {
+        return this == ROLE_PEOPLE;
     }
 }

--- a/src/main/java/es/princip/getp/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/es/princip/getp/domain/member/dto/response/MemberResponse.java
@@ -1,22 +1,43 @@
 package es.princip.getp.domain.member.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import es.princip.getp.domain.member.domain.entity.Member;
 import es.princip.getp.domain.member.domain.enums.MemberType;
+
 import java.time.LocalDateTime;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemberResponse(
     Long memberId,
     String email,
+    String nickname,
     MemberType memberType,
     LocalDateTime createdAt,
-    LocalDateTime updatedAt) {
+    LocalDateTime updatedAt
+) {
 
     public static MemberResponse from(final Member member) {
         return new MemberResponse(
             member.getMemberId(),
             member.getEmail(),
+            null,
             member.getMemberType(),
             member.getCreatedAt(),
-            member.getUpdateAt());
+            member.getUpdatedAt()
+        );
+    }
+
+    public static MemberResponse of(
+        final Member member,
+        final String nickname
+    ) {
+        return new MemberResponse(
+            member.getMemberId(),
+            member.getEmail(),
+            nickname,
+            member.getMemberType(),
+            member.getCreatedAt(),
+            member.getUpdatedAt()
+        );
     }
 }

--- a/src/main/java/es/princip/getp/domain/people/dto/response/people/CreatePeopleResponse.java
+++ b/src/main/java/es/princip/getp/domain/people/dto/response/people/CreatePeopleResponse.java
@@ -2,6 +2,7 @@ package es.princip.getp.domain.people.dto.response.people;
 
 import es.princip.getp.domain.people.domain.entity.People;
 import es.princip.getp.domain.people.domain.enums.PeopleType;
+
 import java.time.LocalDateTime;
 
 public record CreatePeopleResponse(
@@ -24,7 +25,7 @@ public record CreatePeopleResponse(
             people.getPeopleType(),
             people.getProfileImageUri(),
             people.getCreatedAt(),
-            people.getUpdateAt()
+            people.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/es/princip/getp/domain/people/dto/response/people/PeopleResponse.java
+++ b/src/main/java/es/princip/getp/domain/people/dto/response/people/PeopleResponse.java
@@ -2,6 +2,7 @@ package es.princip.getp.domain.people.dto.response.people;
 
 import es.princip.getp.domain.people.domain.entity.People;
 import es.princip.getp.domain.people.domain.enums.PeopleType;
+
 import java.time.LocalDateTime;
 
 public record PeopleResponse(
@@ -24,7 +25,7 @@ public record PeopleResponse(
             people.getPeopleType(),
             people.getProfileImageUri(),
             people.getCreatedAt(),
-            people.getUpdateAt()
+            people.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/es/princip/getp/domain/people/dto/response/people/UpdatePeopleResponse.java
+++ b/src/main/java/es/princip/getp/domain/people/dto/response/people/UpdatePeopleResponse.java
@@ -2,6 +2,7 @@ package es.princip.getp.domain.people.dto.response.people;
 
 import es.princip.getp.domain.people.domain.entity.People;
 import es.princip.getp.domain.people.domain.enums.PeopleType;
+
 import java.time.LocalDateTime;
 
 public record UpdatePeopleResponse(
@@ -24,7 +25,7 @@ public record UpdatePeopleResponse(
             people.getPeopleType(),
             people.getProfileImageUri(),
             people.getCreatedAt(),
-            people.getUpdateAt()
+            people.getUpdatedAt()
         );
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,7 +37,7 @@ spring:
 
   verification-code:
     length: ${VERIFICATION_CODE_LENGTH}
-    expire-time: ${VERIFICATION_CODE_EXPIRATION}
+    expire-time: ${VERIFICATION_CODE_EXPIRE_TIME}
   
   jwt:
     secret: ${JWT_SECRET}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show-sql: true
@@ -37,7 +37,7 @@ spring:
 
   verification-code:
     length: ${VERIFICATION_CODE_LENGTH}
-    expire-time: ${VERIFICATION_CODE_EXPIRATION}
+    expire-time: ${VERIFICATION_CODE_EXPIRE_TIME}
 
   jwt:
     secret: ${JWT_SECRET}

--- a/src/test/java/es/princip/getp/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/es/princip/getp/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,77 @@
+package es.princip.getp.domain.member.controller;
+
+import es.princip.getp.domain.client.service.ClientService;
+import es.princip.getp.domain.member.domain.entity.Member;
+import es.princip.getp.domain.member.domain.enums.MemberType;
+import es.princip.getp.domain.people.domain.entity.People;
+import es.princip.getp.domain.people.service.PeopleService;
+import es.princip.getp.fixture.PeopleFixture;
+import es.princip.getp.global.mock.WithCustomMockUser;
+import es.princip.getp.global.security.details.PrincipalDetails;
+import es.princip.getp.global.support.AbstractControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static es.princip.getp.global.support.FieldDescriptorHelper.getDescriptor;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest extends AbstractControllerTest {
+
+    @MockBean
+    private PeopleService peopleService;
+
+
+
+    @MockBean
+    private ClientService clientService;
+
+    @Nested
+    @DisplayName("사용자는")
+    class GetMyMember {
+
+        @DisplayName("내 회원 정보를 조회할 수 있다.")
+        @WithCustomMockUser(memberType = MemberType.ROLE_PEOPLE)
+        @Test
+        void getMyMember(PrincipalDetails principalDetails) throws Exception {
+            Member member = principalDetails.getMember();
+            Long memberId = member.getMemberId();
+            People people = PeopleFixture.createPeople(member);
+            given(peopleService.getByMemberId(memberId)).willReturn(people);
+
+            mockMvc.perform(get("/member/me")
+                    .header("Authorization", "Bearer ${ACCESS_TOKEN}")
+                )
+                .andExpect(status().isOk())
+                .andDo(
+                    restDocs.document(
+                        requestHeaders(
+                            headerWithName("Authorization").description("Bearer ${ACCESS_TOKEN}")
+                        ),
+                        responseFields(beneathPath("data").withSubsectionId("data"))
+                            .and(
+                                getDescriptor("memberId", "회원 ID"),
+                                getDescriptor("email", "이메일"),
+                                getDescriptor("nickname", "닉네임"),
+                                getDescriptor("memberType", "회원 유형"),
+                                getDescriptor("createdAt", "회원 가입일")
+                                    .attributes(key("format").value("yyyy-MM-dd'T'HH:mm:ss")),
+                                getDescriptor("updatedAt", "회원 정보 수정일")
+                                    .attributes(key("format").value("yyyy-MM-dd'T'HH:mm:ss"))
+                            )
+                    )
+                )
+                .andDo(print());
+        }
+    }
+}

--- a/src/test/java/es/princip/getp/global/mock/WithCustomMockUser.java
+++ b/src/test/java/es/princip/getp/global/mock/WithCustomMockUser.java
@@ -1,14 +1,16 @@
 package es.princip.getp.global.mock;
 
 import es.princip.getp.domain.member.domain.enums.MemberType;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import org.springframework.security.test.context.support.WithSecurityContext;
 
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
 public @interface WithCustomMockUser {
 
+    long memberId() default 1L;
     String email() default "test@example.com";
     MemberType memberType() default MemberType.ROLE_PEOPLE;
 }

--- a/src/test/java/es/princip/getp/global/mock/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/es/princip/getp/global/mock/WithCustomMockUserSecurityContextFactory.java
@@ -2,7 +2,6 @@ package es.princip.getp.global.mock;
 
 import es.princip.getp.domain.member.domain.entity.Member;
 import es.princip.getp.global.security.details.PrincipalDetails;
-import java.util.List;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -10,15 +9,21 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
 
     @Override
     public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
-        String email = annotation.email();
         String role = annotation.memberType().name();
+        LocalDateTime now = LocalDateTime.now();
         Member member = Member.builder()
-            .email(email)
+            .memberId(annotation.memberId())
+            .email(annotation.email())
             .memberType(annotation.memberType())
+            .createdAt(now)
+            .updatedAt(now)
             .build();
         Authentication auth = new UsernamePasswordAuthenticationToken(new PrincipalDetails(member), "",
             List.of(new SimpleGrantedAuthority(role)));

--- a/src/test/java/es/princip/getp/global/support/AbstractControllerTest.java
+++ b/src/test/java/es/princip/getp/global/support/AbstractControllerTest.java
@@ -5,6 +5,7 @@ import es.princip.getp.global.config.SecurityConfig;
 import es.princip.getp.global.config.SecurityTestConfig;
 import es.princip.getp.global.config.SpringRestDocsConfig;
 import es.princip.getp.global.exception.ErrorCode;
+import es.princip.getp.global.mock.PrincipalDetailsParameterResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ActiveProfiles("test")
 @Import({SecurityConfig.class, SecurityTestConfig.class, SpringRestDocsConfig.class})
-@ExtendWith(RestDocumentationExtension.class)
+@ExtendWith({RestDocumentationExtension.class, PrincipalDetailsParameterResolver.class})
 public abstract class AbstractControllerTest {
 
     @Value("${server.servlet.context-path}")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -37,7 +37,7 @@ spring:
 
   verification-code:
     length: ${VERIFICATION_CODE_LENGTH}
-    expire-time: ${VERIFICATION_CODE_EXPIRATION}
+    expire-time: ${VERIFICATION_CODE_EXPIRE_TIME}
 
   jwt:
     secret: ${JWT_SECRET}


### PR DESCRIPTION
## ✨ 구현한 기능
- 내 사용자 정보 조회 기능 구현

## 📢 논의하고 싶은 내용
- 현재 닉네임 필드가 Client 테이블 또는 People 테이블에 있는데, 피플 정보 또는 의뢰자 정보를 기입하지 않은 경우 닉네임의 기본값으로 어떤 값을 반환해줄지 고민입니다. 일단은 이메일 주소를 `@`를 기준으로 파싱해서 반환하는 것으로 처리했습니다.

## 🎸 기타
- 