### PR TITLE
fix: 내 회원 정보 조회 시 피플 또는 의뢰자 정보를 등록하지 않은 경우 404를 반환하는 오류 수정

### DIFF
--- a/src/main/java/es/princip/getp/domain/client/domain/entity/Client.java
+++ b/src/main/java/es/princip/getp/domain/client/domain/entity/Client.java
@@ -1,8 +1,5 @@
 package es.princip.getp.domain.client.domain.entity;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import es.princip.getp.domain.base.BaseTimeEntity;
 import es.princip.getp.domain.client.dto.request.CreateClientRequest;
 import es.princip.getp.domain.client.dto.request.UpdateClientRequest;
@@ -10,21 +7,14 @@ import es.princip.getp.domain.member.domain.entity.Member;
 import es.princip.getp.domain.people.domain.entity.PeopleLike;
 import es.princip.getp.global.domain.values.Address;
 import es.princip.getp.global.domain.values.BankAccount;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -80,6 +70,7 @@ public class Client extends BaseTimeEntity {
         this.address = address;
         this.bankAccount = bankAccount;
         this.member = member;
+        member.setClient(this);
     }
 
     public static Client from(final Member member, final CreateClientRequest request) {

--- a/src/main/java/es/princip/getp/domain/member/controller/MemberController.java
+++ b/src/main/java/es/princip/getp/domain/member/controller/MemberController.java
@@ -1,10 +1,7 @@
 package es.princip.getp.domain.member.controller;
 
-import es.princip.getp.domain.client.service.ClientService;
 import es.princip.getp.domain.member.domain.entity.Member;
-import es.princip.getp.domain.member.domain.enums.MemberType;
 import es.princip.getp.domain.member.dto.response.MemberResponse;
-import es.princip.getp.domain.people.service.PeopleService;
 import es.princip.getp.global.security.details.PrincipalDetails;
 import es.princip.getp.global.util.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,21 +20,12 @@ import static es.princip.getp.global.util.ApiResponse.ApiSuccessResult;
 @RequiredArgsConstructor
 public class MemberController {
 
-    private final PeopleService peopleService;
-    private final ClientService clientService;
-
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiSuccessResult<MemberResponse>> getMyMember(
         @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
         Member member = principalDetails.getMember();
-        Long memberId = member.getMemberId();
-        String email = member.getEmail();
-        MemberType memberType = member.getMemberType();
-        String nickname = memberType.isClient() ? clientService.getByMemberId(memberId).getNickname() :
-                          memberType.isPeople() ? peopleService.getByMemberId(memberId).getNickname() :
-                          email.substring(0, email.indexOf('@'));
-        return ResponseEntity.ok().body(ApiResponse.success(HttpStatus.OK, MemberResponse.of(member, nickname)));
+        return ResponseEntity.ok().body(ApiResponse.success(HttpStatus.OK, MemberResponse.from(member)));
     }
 }

--- a/src/main/java/es/princip/getp/domain/member/domain/entity/Member.java
+++ b/src/main/java/es/princip/getp/domain/member/domain/entity/Member.java
@@ -1,14 +1,13 @@
 package es.princip.getp.domain.member.domain.entity;
 
 import es.princip.getp.domain.base.BaseTimeEntity;
+import es.princip.getp.domain.client.domain.entity.Client;
 import es.princip.getp.domain.member.domain.enums.MemberType;
 import es.princip.getp.domain.member.dto.request.CreateMemberRequest;
+import es.princip.getp.domain.people.domain.entity.People;
 import es.princip.getp.domain.serviceTerm.domain.entity.ServiceTermAgreement;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -35,6 +34,14 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_type")
     private MemberType memberType;
 
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+    @Setter
+    private Client client;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+    @Setter
+    private People people;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<ServiceTermAgreement> serviceTermAgreements = new ArrayList<>();
 
@@ -53,6 +60,14 @@ public class Member extends BaseTimeEntity {
         this.memberType = memberType;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+    }
+
+    public String getNickname() {
+        if (client != null)
+            return client.getNickname();
+        if (people != null)
+            return people.getNickname();
+        return null;
     }
 
     public static Member from(CreateMemberRequest request) {

--- a/src/main/java/es/princip/getp/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/es/princip/getp/domain/member/dto/response/MemberResponse.java
@@ -1,12 +1,11 @@
 package es.princip.getp.domain.member.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import es.princip.getp.domain.member.domain.entity.Member;
 import es.princip.getp.domain.member.domain.enums.MemberType;
 
 import java.time.LocalDateTime;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+
 public record MemberResponse(
     Long memberId,
     String email,
@@ -20,21 +19,7 @@ public record MemberResponse(
         return new MemberResponse(
             member.getMemberId(),
             member.getEmail(),
-            null,
-            member.getMemberType(),
-            member.getCreatedAt(),
-            member.getUpdatedAt()
-        );
-    }
-
-    public static MemberResponse of(
-        final Member member,
-        final String nickname
-    ) {
-        return new MemberResponse(
-            member.getMemberId(),
-            member.getEmail(),
-            nickname,
+            member.getNickname(),
             member.getMemberType(),
             member.getCreatedAt(),
             member.getUpdatedAt()

--- a/src/main/java/es/princip/getp/domain/people/domain/entity/People.java
+++ b/src/main/java/es/princip/getp/domain/people/domain/entity/People.java
@@ -4,17 +4,7 @@ import es.princip.getp.domain.base.BaseTimeEntity;
 import es.princip.getp.domain.member.domain.entity.Member;
 import es.princip.getp.domain.people.domain.enums.PeopleType;
 import es.princip.getp.domain.people.dto.request.UpdatePeopleRequest;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -69,6 +59,7 @@ public class People extends BaseTimeEntity {
         this.peopleType = peopleType;
         this.profileImageUri = profileImageUri;
         this.member = member;
+        member.setPeople(this);
     }
 
     public void update(final UpdatePeopleRequest request) {

--- a/src/test/java/es/princip/getp/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/es/princip/getp/domain/member/controller/MemberControllerTest.java
@@ -1,11 +1,6 @@
 package es.princip.getp.domain.member.controller;
 
-import es.princip.getp.domain.client.service.ClientService;
-import es.princip.getp.domain.member.domain.entity.Member;
 import es.princip.getp.domain.member.domain.enums.MemberType;
-import es.princip.getp.domain.people.domain.entity.People;
-import es.princip.getp.domain.people.service.PeopleService;
-import es.princip.getp.fixture.PeopleFixture;
 import es.princip.getp.global.mock.WithCustomMockUser;
 import es.princip.getp.global.security.details.PrincipalDetails;
 import es.princip.getp.global.support.AbstractControllerTest;
@@ -13,43 +8,29 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
 
+import static es.princip.getp.fixture.ClientFixture.createClient;
+import static es.princip.getp.fixture.PeopleFixture.createPeople;
 import static es.princip.getp.global.support.FieldDescriptorHelper.getDescriptor;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MemberController.class)
 class MemberControllerTest extends AbstractControllerTest {
 
-    @MockBean
-    private PeopleService peopleService;
-
-
-
-    @MockBean
-    private ClientService clientService;
-
     @Nested
-    @DisplayName("사용자는")
+    @DisplayName("사용자는 내 회원 정보를 조회할 수 있다.")
     class GetMyMember {
 
-        @DisplayName("내 회원 정보를 조회할 수 있다.")
-        @WithCustomMockUser(memberType = MemberType.ROLE_PEOPLE)
-        @Test
-        void getMyMember(PrincipalDetails principalDetails) throws Exception {
-            Member member = principalDetails.getMember();
-            Long memberId = member.getMemberId();
-            People people = PeopleFixture.createPeople(member);
-            given(peopleService.getByMemberId(memberId)).willReturn(people);
-
-            mockMvc.perform(get("/member/me")
+        ResultActions perform() throws Exception {
+            return mockMvc.perform(get("/member/me")
                     .header("Authorization", "Bearer ${ACCESS_TOKEN}")
                 )
                 .andExpect(status().isOk())
@@ -72,6 +53,36 @@ class MemberControllerTest extends AbstractControllerTest {
                     )
                 )
                 .andDo(print());
+        }
+
+        @WithCustomMockUser(memberType = MemberType.ROLE_PEOPLE)
+        @Test
+        void getMyMember_WhenMemberTypeIsPeople(PrincipalDetails principalDetails) throws Exception {
+            createPeople(principalDetails.getMember());
+
+            perform();
+        }
+
+        @WithCustomMockUser(memberType = MemberType.ROLE_CLIENT)
+        @Test
+        void getMyMember_WhenMemberTypeIsClient(PrincipalDetails principalDetails) throws Exception {
+            createClient(principalDetails.getMember());
+
+            perform();
+        }
+
+        @WithCustomMockUser(memberType = MemberType.ROLE_PEOPLE)
+        @Test
+        void getMyMember_WhenPeopleIsNotRegistered() throws Exception {
+            perform()
+                .andExpect(jsonPath("$.data.nickname").isEmpty());
+        }
+
+        @WithCustomMockUser(memberType = MemberType.ROLE_CLIENT)
+        @Test
+        void getMyMember_WhenClientIsNotRegistered() throws Exception {
+            perform()
+                .andExpect(jsonPath("$.data.nickname").isEmpty());
         }
     }
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- 내 회원 정보 조회 시 피플 또는 의뢰자 정보를 등록하지 않은 경우 404를 반환하는 오류 수정

## 📢 논의하고 싶은 내용
-

## 🎸 기타
- 