### PR TITLE
GETP-144 test: 내 피플 정보 조회 컨트롤러 단위 테스트 및 API 문서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -39,3 +39,6 @@ include::{docdir}/people/get-people.adoc[]
 
 === 피플 목록 조회
 include::{docdir}/people/get-card-people-page.adoc[]
+
+=== 내 피플 정보 조회
+include::{docdir}/people/get-my-people.adoc[]

--- a/src/docs/asciidoc/people/get-my-people.adoc
+++ b/src/docs/asciidoc/people/get-my-people.adoc
@@ -1,0 +1,1 @@
+operation::/get-my-people/get-my-people[snippets="http-request,request-headers,http-response,response-fields-data"]

--- a/src/main/java/es/princip/getp/domain/people/domain/entity/People.java
+++ b/src/main/java/es/princip/getp/domain/people/domain/entity/People.java
@@ -42,7 +42,7 @@ public class People extends BaseTimeEntity {
         final PeopleType peopleType,
         final Member member
     ) {
-        this.email = email == null ? member.getEmail() : email;
+        this.email = email;
         this.peopleType = peopleType;
         this.member = member;
     }
@@ -53,6 +53,10 @@ public class People extends BaseTimeEntity {
             .peopleType(request.peopleType())
             .member(member)
             .build();
+    }
+
+    public String getEmail() {
+        return this.email == null ? this.member.getEmail() : this.email;
     }
 
     public String getNickname() {

--- a/src/test/java/es/princip/getp/domain/people/controller/MyPeopleControllerTest.java
+++ b/src/test/java/es/princip/getp/domain/people/controller/MyPeopleControllerTest.java
@@ -1,0 +1,79 @@
+package es.princip.getp.domain.people.controller;
+
+import es.princip.getp.domain.member.domain.entity.Member;
+import es.princip.getp.domain.people.domain.entity.People;
+import es.princip.getp.domain.people.service.PeopleProfileService;
+import es.princip.getp.domain.people.service.PeopleService;
+import es.princip.getp.global.controller.ErrorCodeController;
+import es.princip.getp.global.mock.WithCustomMockUser;
+import es.princip.getp.global.security.details.PrincipalDetails;
+import es.princip.getp.global.support.AbstractControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDateTime;
+
+import static es.princip.getp.domain.member.domain.enums.MemberType.ROLE_PEOPLE;
+import static es.princip.getp.domain.people.fixture.PeopleFixture.createPeople;
+import static es.princip.getp.global.support.FieldDescriptorHelper.getDescriptor;
+import static es.princip.getp.global.support.HeaderDescriptorHelper.authorizationHeaderDescriptor;
+import static es.princip.getp.global.support.PayloadDocumentationHelper.responseFields;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({MyPeopleController.class, ErrorCodeController.class})
+class MyPeopleControllerTest extends AbstractControllerTest {
+
+    @MockBean
+    private PeopleService peopleService;
+
+    @MockBean
+    private PeopleProfileService peopleProfileService;
+
+    @DisplayName("피플은 자신의 피플 정보를 조회할 수 있다.")
+    @Nested
+    class GetMyPeople {
+
+        @WithCustomMockUser(memberType = ROLE_PEOPLE)
+        @Test
+        void getMyPeople(PrincipalDetails principalDetails) throws Exception {
+            Member member = principalDetails.getMember();
+            People people = spy(createPeople(member));
+
+            given(people.getPeopleId()).willReturn(1L);
+            given(people.getCreatedAt()).willReturn(LocalDateTime.now());
+            given(people.getUpdatedAt()).willReturn(LocalDateTime.now());
+
+            given(peopleService.getByMemberId(anyLong())).willReturn(people);
+
+            mockMvc.perform(get("/people/me")
+                .header("Authorization", "Bearer ${ACCESS_TOKEN}")
+                .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(
+                    restDocs.document(
+                        requestHeaders(authorizationHeaderDescriptor()),
+                        responseFields(
+                            getDescriptor("peopleId", "피플 ID"),
+                            getDescriptor("nickname", "닉네임"),
+                            getDescriptor("email", "이메일(기본값은 회원 가입 시 기입한 이메일)"),
+                            getDescriptor("phoneNumber", "전화번호"),
+                            getDescriptor("peopleType", "피플 유형"),
+                            getDescriptor("profileImageUri", "프로필 이미지 URI"),
+                            getDescriptor("createdAt", "피플 정보 등록일"),
+                            getDescriptor("updatedAt", "피플 정보 수정일")
+                        )
+                    )
+                )
+                .andDo(print());
+        }
+    }
+}

--- a/src/test/java/es/princip/getp/domain/people/fixture/PeopleFixture.java
+++ b/src/test/java/es/princip/getp/domain/people/fixture/PeopleFixture.java
@@ -1,6 +1,7 @@
 package es.princip.getp.domain.people.fixture;
 
 import es.princip.getp.domain.member.domain.entity.Member;
+import es.princip.getp.domain.member.dto.request.UpdateMemberRequest;
 import es.princip.getp.domain.people.domain.entity.People;
 import es.princip.getp.domain.people.domain.enums.PeopleType;
 import es.princip.getp.domain.people.dto.request.CreatePeopleRequest;
@@ -20,7 +21,7 @@ public class PeopleFixture {
     public static String PHONE_NUMBER = "01012345678";
     public static PeopleType PEOPLE_TYPE = PeopleType.INDIVIDUAL;
     public static String PROFILE_IMAGE_URI = "/images/1/profile/image.jpeg";
-    public static String UPDATED_NICKNAME = "scv1702";
+    public static String UPDATE = "updated_";
 
     public static CreatePeopleRequest createPeopleRequest() {
         return new CreatePeopleRequest(
@@ -34,8 +35,8 @@ public class PeopleFixture {
 
     public static UpdatePeopleRequest updatePeopleRequest() {
         return new UpdatePeopleRequest(
-            UPDATED_NICKNAME,
-            EMAIL,
+            UPDATE + NICKNAME,
+            UPDATE + EMAIL,
             PHONE_NUMBER,
             PEOPLE_TYPE,
             PROFILE_IMAGE_URI
@@ -43,7 +44,9 @@ public class PeopleFixture {
     }
 
     public static People createPeople(Member member) {
-        return People.from(member, createPeopleRequest());
+        CreatePeopleRequest request = createPeopleRequest();
+        member.update(UpdateMemberRequest.from(request));
+        return People.from(member, request);
     }
 
     public static List<People> createPeopleList(List<Member> memberList) {

--- a/src/test/java/es/princip/getp/domain/people/service/PeopleServiceTest.java
+++ b/src/test/java/es/princip/getp/domain/people/service/PeopleServiceTest.java
@@ -30,7 +30,9 @@ import static es.princip.getp.domain.people.fixture.PeopleFixture.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -163,11 +165,7 @@ public class PeopleServiceTest {
 
         @BeforeEach
         void setUp() {
-            mockMember = Mockito.spy(createMember(
-                request.nickname(),
-                request.phoneNumber(),
-                request.profileImageUri()
-            ));
+            mockMember = Mockito.spy(createMember());
             given(mockMember.getMemberId()).willReturn(1L);
             mockPeople = createPeople(mockMember);
         }
@@ -175,12 +173,17 @@ public class PeopleServiceTest {
         @Test
         @DisplayName("피플 정보를 수정한다.")
         void update() {
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.from(request);
             given(peopleRepository.findByMember_MemberId(mockMember.getMemberId()))
                 .willReturn(Optional.of(mockPeople));
+            doAnswer(invocation -> {
+                mockMember.update(updateMemberRequest);
+                return null;
+            }).when(memberService).update(anyLong(), any(UpdateMemberRequest.class));
 
             People updated = peopleService.update(mockMember.getMemberId(), request);
 
-            verify(memberService).update(mockMember.getMemberId(), UpdateMemberRequest.from(request));
+            verify(memberService).update(mockMember.getMemberId(), updateMemberRequest);
             assertSoftly(softly -> {
                 softly.assertThat(updated.getNickname()).isEqualTo(request.nickname());
                 softly.assertThat(updated.getEmail()).isEqualTo(request.email());


### PR DESCRIPTION
## ✨ 구현한 기능
- 내 피플 정보 조회 컨트롤러 단위 테스트 및 API 문서 작성
- 수소 서버 CI/CD 재설정
- 임시 서버에서 수소 서버로 DNS 재설정
- 수소 서버에 `*.princip.es`로 Cloudflare TLS 인증서 설정

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 