### PR TITLE
refactor: 프로젝트 지원에 대한 비즈니스 로직을 PeopleApplicationService에서 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ dependencies {
     implementation 'com.sun.mail:jakarta.mail:2.0.1'
     implementation 'org.springframework.boot:spring-boot-starter-mail:3.2.1'
 
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
     // AOP
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 

--- a/src/main/java/es/princip/getp/domain/common/domain/URL.java
+++ b/src/main/java/es/princip/getp/domain/common/domain/URL.java
@@ -24,7 +24,8 @@ public class URL {
     @NotNull
     private String value;
 
-    private URL(final String url) {
+    public URL(final String url) {
+        validate(url);
         this.value = url;
     }
 
@@ -39,7 +40,6 @@ public class URL {
     }
 
     public static URL from(final String url) {
-        validate(url);
         return new URL(url);
     }
 }

--- a/src/main/java/es/princip/getp/domain/common/infra/URLMapper.java
+++ b/src/main/java/es/princip/getp/domain/common/infra/URLMapper.java
@@ -1,0 +1,10 @@
+package es.princip.getp.domain.common.infra;
+
+import es.princip.getp.domain.common.domain.URL;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface URLMapper {
+
+    URL stringToURL(String url);
+}

--- a/src/main/java/es/princip/getp/domain/people/command/domain/PeopleProfileChecker.java
+++ b/src/main/java/es/princip/getp/domain/people/command/domain/PeopleProfileChecker.java
@@ -1,0 +1,19 @@
+package es.princip.getp.domain.people.command.domain;
+
+import es.princip.getp.domain.people.exception.PeopleProfileNotRegisteredException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PeopleProfileChecker {
+
+    private final PeopleProfileRepository peopleProfileRepository;
+
+    public void checkPeopleProfileIsRegistered(final People people) {
+        final Long peopleId = people.getPeopleId();
+        if (!peopleProfileRepository.existsByPeopleId(peopleId)) {
+            throw new PeopleProfileNotRegisteredException();
+        }
+    }
+}

--- a/src/main/java/es/princip/getp/domain/people/exception/PeopleProfileNotRegisteredException.java
+++ b/src/main/java/es/princip/getp/domain/people/exception/PeopleProfileNotRegisteredException.java
@@ -1,4 +1,4 @@
-package es.princip.getp.domain.project.exception;
+package es.princip.getp.domain.people.exception;
 
 import es.princip.getp.infra.exception.BusinessLogicException;
 

--- a/src/main/java/es/princip/getp/domain/project/command/application/ProjectApplicationService.java
+++ b/src/main/java/es/princip/getp/domain/project/command/application/ProjectApplicationService.java
@@ -1,59 +1,44 @@
 package es.princip.getp.domain.project.command.application;
 
 import es.princip.getp.domain.people.command.domain.People;
-import es.princip.getp.domain.people.command.domain.PeopleProfileRepository;
 import es.princip.getp.domain.people.command.domain.PeopleRepository;
+import es.princip.getp.domain.project.command.application.command.ApplyProjectCommand;
 import es.princip.getp.domain.project.command.domain.*;
-import es.princip.getp.domain.project.command.presentation.dto.request.ApplyProjectRequest;
-import es.princip.getp.domain.project.exception.PeopleProfileNotRegisteredException;
-import es.princip.getp.domain.project.exception.ProjectApplicationClosedException;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static es.princip.getp.domain.project.command.domain.ProjectApplicationStatus.APPLICATION_COMPLETED;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProjectApplicationService {
 
-    private final PeopleRepository peopleRepository;
     private final ProjectRepository projectRepository;
-    private final PeopleProfileRepository peopleProfileRepository;
+    private final PeopleRepository peopleRepository;
     private final ProjectApplicationRepository projectApplicationRepository;
+    private final ProjectApplier projectApplier;
 
+    /**
+     * 프로젝트 지원
+     * 
+     * @param command 프로젝트 지원 명령
+     * @return 프로젝트 지원 ID
+     */
     @Transactional
-    public Long applyForProject(Long memberId, Long projectId, ApplyProjectRequest request) {
-        final Project project = projectRepository.findById(projectId).orElseThrow();
-
-        if (project.isApplicationClosed()) {
-            throw new ProjectApplicationClosedException();
-        }
-
-        final People people = peopleRepository.findByMemberId(memberId).orElseThrow();
-
-        // 피플 프로필을 등록한 경우에만 프로젝트에 지원할 수 있음
-        if (!peopleProfileRepository.existsByPeopleId(people.getMemberId())) {
-            throw new PeopleProfileNotRegisteredException();
-        }
-
-        final ExpectedDuration expectedDuration = ExpectedDuration.from(request.expectedDuration());
-        final List<AttachmentFile> attachmentFiles = request.attachmentUris().stream()
-            .map(AttachmentFile::from)
-            .toList();
-
-        final ProjectApplication application = ProjectApplication.builder()
-            .applicantId(people.getPeopleId())
-            .projectId(projectId)
-            .expectedDuration(expectedDuration)
-            .description(request.description())
-            .attachmentFiles(attachmentFiles)
-            .applicationStatus(APPLICATION_COMPLETED)
-            .build();
-
-        return projectApplicationRepository.save(application).getApplicationId();
+    public Long applyForProject(final ApplyProjectCommand command) {
+        final People people = peopleRepository.findByMemberId(command.memberId())
+            .orElseThrow(() -> new EntityNotFoundException("해당 피플이 존재하지 않습니다."));
+        final Project project = projectRepository.findById(command.projectId())
+            .orElseThrow(() -> new EntityNotFoundException("해당 프로젝트가 존재하지 않습니다."));
+        final ProjectApplication application = projectApplier.applyForProject(
+            people,
+            project,
+            command.expectedDuration(),
+            command.description(),
+            command.attachmentFiles()
+        );
+        projectApplicationRepository.save(application);
+        return application.getApplicationId();
     }
 }

--- a/src/main/java/es/princip/getp/domain/project/command/application/ProjectService.java
+++ b/src/main/java/es/princip/getp/domain/project/command/application/ProjectService.java
@@ -30,7 +30,7 @@ public class ProjectService {
             throw new ApplicationDurationIsNotBeforeEstimatedDurationException();
         }
 
-        final List<AttachmentFile> attachmentFiles = request.attachmentUris().stream()
+        final List<AttachmentFile> attachmentFiles = request.attachmentFiles().stream()
             .map(AttachmentFile::from)
             .toList();
         final List<Hashtag> hashtags = request.hashtags().stream()

--- a/src/main/java/es/princip/getp/domain/project/command/application/command/ApplyProjectCommand.java
+++ b/src/main/java/es/princip/getp/domain/project/command/application/command/ApplyProjectCommand.java
@@ -1,0 +1,15 @@
+package es.princip.getp.domain.project.command.application.command;
+
+import es.princip.getp.domain.project.command.domain.AttachmentFile;
+import es.princip.getp.domain.project.command.domain.ExpectedDuration;
+
+import java.util.List;
+
+public record ApplyProjectCommand(
+    Long memberId,
+    Long projectId,
+    ExpectedDuration expectedDuration,
+    String description,
+    List<AttachmentFile> attachmentFiles
+) {
+}

--- a/src/main/java/es/princip/getp/domain/project/command/domain/AttachmentFile.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/AttachmentFile.java
@@ -15,7 +15,7 @@ public class AttachmentFile {
     @Embedded
     private URL url;
 
-    private AttachmentFile(final URL url) {
+    public AttachmentFile(final URL url) {
         this.url = url;
     }
 

--- a/src/main/java/es/princip/getp/domain/project/command/domain/ExpectedDuration.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/ExpectedDuration.java
@@ -9,9 +9,10 @@ import java.time.LocalDate;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+
 public class ExpectedDuration extends Duration {
 
-    private ExpectedDuration(final LocalDate startDate, final LocalDate endDate) {
+    public ExpectedDuration(final LocalDate startDate, final LocalDate endDate) {
         super(startDate, endDate);
     }
 

--- a/src/main/java/es/princip/getp/domain/project/command/domain/ProjectApplier.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/ProjectApplier.java
@@ -1,0 +1,51 @@
+package es.princip.getp.domain.project.command.domain;
+
+import es.princip.getp.domain.people.command.domain.People;
+import es.princip.getp.domain.people.command.domain.PeopleProfileChecker;
+import es.princip.getp.domain.project.exception.ProjectApplicationClosedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static es.princip.getp.domain.project.command.domain.ProjectApplicationStatus.APPLICATION_COMPLETED;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectApplier {
+
+    private final PeopleProfileChecker peopleProfileChecker;
+
+    /**
+     * 프로젝트 지원
+     *
+     * @param people 지원하는 피플
+     * @param project 지원할 프로젝트
+     * @param expectedDuration 예상 기간
+     * @param description 설명
+     * @param attachmentFiles 첨부 파일
+     * @return 프로젝트 지원
+     */
+    public ProjectApplication applyForProject(
+        final People people,
+        final Project project,
+        final ExpectedDuration expectedDuration,
+        final String description,
+        final List<AttachmentFile> attachmentFiles
+    ) {
+        if (project.isApplicationClosed()) {
+            throw new ProjectApplicationClosedException();
+        }
+
+        peopleProfileChecker.checkPeopleProfileIsRegistered(people);
+
+        return ProjectApplication.builder()
+            .applicantId(people.getPeopleId())
+            .projectId(project.getProjectId())
+            .expectedDuration(expectedDuration)
+            .description(description)
+            .attachmentFiles(attachmentFiles)
+            .applicationStatus(APPLICATION_COMPLETED)
+            .build();
+    }
+}

--- a/src/main/java/es/princip/getp/domain/project/command/infra/ProjectMapper.java
+++ b/src/main/java/es/princip/getp/domain/project/command/infra/ProjectMapper.java
@@ -1,0 +1,16 @@
+package es.princip.getp.domain.project.command.infra;
+
+import es.princip.getp.domain.common.domain.URL;
+import es.princip.getp.domain.common.infra.URLMapper;
+import es.princip.getp.domain.project.command.application.command.ApplyProjectCommand;
+import es.princip.getp.domain.project.command.domain.AttachmentFile;
+import es.princip.getp.domain.project.command.presentation.dto.request.ApplyProjectRequest;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring", uses = {URLMapper.class})
+public interface ProjectMapper {
+
+    ApplyProjectCommand toCommand(Long memberId, Long projectId, ApplyProjectRequest request);
+
+    AttachmentFile stringToAttachmentFile(URL url);
+}

--- a/src/main/java/es/princip/getp/domain/project/command/infra/ProjectMapper.java
+++ b/src/main/java/es/princip/getp/domain/project/command/infra/ProjectMapper.java
@@ -12,5 +12,5 @@ public interface ProjectMapper {
 
     ApplyProjectCommand toCommand(Long memberId, Long projectId, ApplyProjectRequest request);
 
-    AttachmentFile stringToAttachmentFile(URL url);
+    AttachmentFile urlToAttachmentFile(URL url);
 }

--- a/src/main/java/es/princip/getp/domain/project/command/presentation/ProjectApplicationController.java
+++ b/src/main/java/es/princip/getp/domain/project/command/presentation/ProjectApplicationController.java
@@ -1,6 +1,8 @@
 package es.princip.getp.domain.project.command.presentation;
 
 import es.princip.getp.domain.project.command.application.ProjectApplicationService;
+import es.princip.getp.domain.project.command.application.command.ApplyProjectCommand;
+import es.princip.getp.domain.project.command.infra.ProjectMapper;
 import es.princip.getp.domain.project.command.presentation.dto.request.ApplyProjectRequest;
 import es.princip.getp.domain.project.command.presentation.dto.response.ApplyProjectResponse;
 import es.princip.getp.infra.dto.response.ApiResponse;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class ProjectApplicationController {
 
     private final ProjectApplicationService projectApplicationService;
+    private final ProjectMapper projectMapper;
 
     /**
      * 프로젝트 지원
@@ -35,7 +38,8 @@ public class ProjectApplicationController {
         @AuthenticationPrincipal final PrincipalDetails principalDetails,
         @PathVariable Long projectId) {
         final Long memberId = principalDetails.getMember().getMemberId();
-        final Long applicationId = projectApplicationService.applyForProject(memberId, projectId, request);
+        final ApplyProjectCommand command = projectMapper.toCommand(memberId, projectId, request);
+        final Long applicationId = projectApplicationService.applyForProject(command);
         final ApplyProjectResponse response = new ApplyProjectResponse(applicationId);
         return ApiResponse.success(HttpStatus.CREATED, response);
     }

--- a/src/main/java/es/princip/getp/domain/project/command/presentation/dto/request/ApplyProjectRequest.java
+++ b/src/main/java/es/princip/getp/domain/project/command/presentation/dto/request/ApplyProjectRequest.java
@@ -8,6 +8,6 @@ import java.util.List;
 public record ApplyProjectRequest(
     @NotNull Duration expectedDuration,
     @NotNull String description,
-    @NotNull List<String> attachmentUris
+    @NotNull List<String> attachmentFiles
 ) {
 }

--- a/src/main/java/es/princip/getp/domain/project/command/presentation/dto/request/RegisterProjectRequest.java
+++ b/src/main/java/es/princip/getp/domain/project/command/presentation/dto/request/RegisterProjectRequest.java
@@ -17,7 +17,7 @@ public record RegisterProjectRequest(
     @NotBlank String description,
     @Enum MeetingType meetingType,
     @Enum ProjectCategory category,
-    @NotNull List<String> attachmentUris,
+    @NotNull List<String> attachmentFiles,
     @NotNull List<String> hashtags
 ) {
 }

--- a/src/test/java/es/princip/getp/domain/common/infra/URLMapperTest.java
+++ b/src/test/java/es/princip/getp/domain/common/infra/URLMapperTest.java
@@ -1,0 +1,25 @@
+package es.princip.getp.domain.common.infra;
+
+import es.princip.getp.domain.common.domain.URL;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {URLMapperImpl.class})
+class URLMapperTest {
+
+    @Autowired
+    private URLMapper urlMapper;
+
+    @Test
+    void stringToURL() {
+        final URL url = urlMapper.stringToURL("https://url.com");
+
+        assertThat(url).isNotNull();
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/command/infra/ProjectMapperTest.java
+++ b/src/test/java/es/princip/getp/domain/project/command/infra/ProjectMapperTest.java
@@ -42,9 +42,9 @@ class ProjectMapperTest {
     }
 
     @Test
-    void stringToAttachmentFile() {
+    void urlToAttachmentFile() {
         final URL url = new URL("https://url.com");
-        final AttachmentFile attachmentFile = projectMapper.stringToAttachmentFile(url);
+        final AttachmentFile attachmentFile = projectMapper.urlToAttachmentFile(url);
         
         assertThat(attachmentFile).isNotNull();
     }

--- a/src/test/java/es/princip/getp/domain/project/command/infra/ProjectMapperTest.java
+++ b/src/test/java/es/princip/getp/domain/project/command/infra/ProjectMapperTest.java
@@ -1,0 +1,51 @@
+package es.princip.getp.domain.project.command.infra;
+
+import es.princip.getp.domain.common.domain.Duration;
+import es.princip.getp.domain.common.domain.URL;
+import es.princip.getp.domain.common.infra.URLMapperImpl;
+import es.princip.getp.domain.project.command.application.command.ApplyProjectCommand;
+import es.princip.getp.domain.project.command.domain.AttachmentFile;
+import es.princip.getp.domain.project.command.presentation.dto.request.ApplyProjectRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ProjectMapperImpl.class, URLMapperImpl.class})
+class ProjectMapperTest {
+
+    @Autowired
+    private ProjectMapper projectMapper;
+
+    @Test
+    void toCommand() {
+        final ApplyProjectRequest request = new ApplyProjectRequest(
+            Duration.of(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 1, 2)
+            ),
+            "description",
+            List.of("https://url1.com", "https://url2.com")
+        );
+        final ApplyProjectCommand command = projectMapper.toCommand(1L, 1L, request);
+
+        assertThat(command).usingRecursiveComparison().isNotNull();
+    }
+
+    @Test
+    void stringToAttachmentFile() {
+        final URL url = new URL("https://url.com");
+        final AttachmentFile attachmentFile = projectMapper.stringToAttachmentFile(url);
+        
+        assertThat(attachmentFile).isNotNull();
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/command/presentation/ProjectApplicationControllerTest.java
+++ b/src/test/java/es/princip/getp/domain/project/command/presentation/ProjectApplicationControllerTest.java
@@ -3,9 +3,12 @@ package es.princip.getp.domain.project.command.presentation;
 import es.princip.getp.domain.common.domain.Duration;
 import es.princip.getp.domain.member.command.domain.model.MemberType;
 import es.princip.getp.domain.project.command.application.ProjectApplicationService;
+import es.princip.getp.domain.project.command.application.command.ApplyProjectCommand;
+import es.princip.getp.domain.project.command.infra.ProjectMapper;
 import es.princip.getp.domain.project.command.presentation.dto.request.ApplyProjectRequest;
 import es.princip.getp.infra.annotation.WithCustomMockUser;
 import es.princip.getp.infra.support.AbstractControllerTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,20 +18,29 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProjectApplicationController.class)
 class ProjectApplicationControllerTest extends AbstractControllerTest {
 
     @MockBean
+    private ProjectMapper projectMapper;
+
+    @MockBean
     private ProjectApplicationService projectApplicationService;
+
+    @BeforeEach
+    void setUp() {
+        given(projectMapper.toCommand(any(), any(), any())).willReturn(mock(ApplyProjectCommand.class));
+    }
 
     @Nested
     @DisplayName("프로젝트 지원")
     class ApplyForProject {
 
-        private final Long memberId = 1L;
         private final Long projectId = 1L;
         private final Long applicationId = 1L;
         private final ApplyProjectRequest request = new ApplyProjectRequest(
@@ -41,7 +53,7 @@ class ProjectApplicationControllerTest extends AbstractControllerTest {
         @WithCustomMockUser(memberType = MemberType.ROLE_PEOPLE)
         @DisplayName("피플은 프로젝트에 지원할 수 있다.")
         void applyForProject() throws Exception {
-            given(projectApplicationService.applyForProject(memberId, projectId, request))
+            given(projectApplicationService.applyForProject(any(ApplyProjectCommand.class)))
                 .willReturn(applicationId);
 
             mockMvc.perform(post("/projects/{projectId}/applications", projectId)


### PR DESCRIPTION
## ✨ 구현한 기능
- 프로젝트 지원에 대한 비즈니스 로직을 `PeopleApplicationService`에서 분리
- DTO 개수가 늘어남에 따라 효율적으로 관리하기 위해 `MapStruct` 의존성 설치

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 