### PR TITLE
fix: 내 회원 정보 조회에서 닉네임, 프로필 이미지를 등록하지 않은 경우 NPE가 발생하는 오류 수정

### DIFF
--- a/src/main/java/es/princip/getp/domain/member/query/dto/MemberResponse.java
+++ b/src/main/java/es/princip/getp/domain/member/query/dto/MemberResponse.java
@@ -2,8 +2,11 @@ package es.princip.getp.domain.member.query.dto;
 
 import es.princip.getp.domain.member.command.domain.model.Member;
 import es.princip.getp.domain.member.command.domain.model.MemberType;
+import es.princip.getp.domain.member.command.domain.model.Nickname;
+import es.princip.getp.domain.member.command.domain.model.ProfileImage;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public record MemberResponse(
     Long memberId,
@@ -18,8 +21,12 @@ public record MemberResponse(
         return new MemberResponse(
             member.getMemberId(),
             member.getEmail().getValue(),
-            member.getNickname().getValue(),
-            member.getProfileImage().getUri(),
+            Optional.ofNullable(member.getNickname())
+                .map(Nickname::getValue)
+                .orElse(null),
+            Optional.ofNullable(member.getProfileImage())
+                .map(ProfileImage::getUri)
+                .orElse(null),
             member.getMemberType(),
             member.getCreatedAt(),
             member.getUpdatedAt()


### PR DESCRIPTION
## ✨ 구현한 기능
- 내 회원 정보 조회에서 닉네임, 프로필 이미지를 등록하지 않은 경우 NPE가 발생하는 오류 수정

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 