### PR TITLE
GETP-161 test: 의뢰자 정보 등록 컨트롤러 단위 테스트 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -12,12 +12,21 @@
 
 == 인증
 === 회원 가입
+
+사용자는 회원 가입을 할 수 있습니다.
+
 include::{docdir}/auth/signup.adoc[]
 
 === 로그인
+
+사용자는 로그인을 할 수 있습니다.
+
 include::{docdir}/auth/login.adoc[]
 
 === 회원 가입 시 이메일 인증 코드 전송
+
+사용자는 회원 가입 시 이메일을 인증해야 합니다.
+
 include::{docdir}/auth/send-email-verification-code-for-sign-up.adoc[]
 
 === Access Token 및 Refresh Token 재발급
@@ -36,45 +45,79 @@ include::{docdir}/member/get-my-member.adoc[]
 
 === 내 프로필 사진 등록
 
+회원은 자신의 프로필 사진을 등록할 수 있습니다.
+
 include::{docdir}/member/upload-profile-image.adoc[]
+
+== 의뢰자
+
+=== 내 의뢰자 정보 등록
+
+의뢰자는 자신의 의뢰자 정보를 등록할 수 있습니다.
+
+include::{docdir}/my-client/register-my-client.adoc[]
 
 == 피플
 
 === 피플 상세 조회
+
+사용자는 피플의 상세 정보를 조회할 수 있습니다.
+
 include::{docdir}/people/get-people.adoc[]
 
 === 피플 목록 조회
+
+사용자는 피플 목록을 조회할 수 있습니다.
+
 include::{docdir}/people/get-card-people-page.adoc[]
 
 === 내 피플 정보 등록
+
+피플은 자신의 피플 정보를 등록할 수 있습니다.
+
 include::{docdir}/my-people/create-my-people.adoc[]
 
 === 내 피플 정보 조회
+
+피플은 자신의 피플 정보를 조회할 수 있습니다.
+
 include::{docdir}/my-people/get-my-people.adoc[]
 
 === 내 피플 정보 수정
+
+피플은 자신의 피플 정보를 수정할 수 있습니다.
+
 include::{docdir}/my-people/update-my-people.adoc[]
 
 === 내 피플 프로필 등록
+
+피플은 자신의 프로필을 등록할 수 있습니다.
+
 include::{docdir}/my-people-profile/write-my-people-profile.adoc[]
 
 === 내 피플 프로필 조회
+
+피플은 자신의 프로필을 조회할 수 있습니다.
+
 include::{docdir}/my-people-profile/get-my-people-profile.adoc[]
 
 === 내 피플 프로필 수정
+
+피플은 자신의 프로필을 수정할 수 있습니다.
+
 include::{docdir}/my-people-profile/edit-my-people-profile.adoc[]
 
 == 프로젝트
 
 === 프로젝트 상세 조회
 
-프로젝트 상세 정보를 조회합니다.
+사용자는 프로젝트의 상세 정보를 조회할 수 있습니다.
 
 include::{docdir}/project/get-project-by-project-Id.adoc[]
 
 === 프로젝트 목록 조회
 
-프로젝트 목록을 조회합니다.
+사용자는 프로젝트 목록을 조회할 수 있습니다.
 
 include::{docdir}/project/get-projects.adoc[]
 
@@ -86,7 +129,7 @@ include::{docdir}/project/like-project.adoc[]
 
 === 프로젝트 좋아요 취소
 
-피플은 좋아요를 누른 프로젝트에 대해 좋아요를 취소할 수 있습니다.
+피플은 마음에 드는 프로젝트에 눌렀던 좋아요를 취소할 수 있습니다.
 
 include::{docdir}/project/unlike-project.adoc[]
 

--- a/src/docs/asciidoc/my-client/register-my-client.adoc
+++ b/src/docs/asciidoc/my-client/register-my-client.adoc
@@ -1,0 +1,1 @@
+operation::/register-my-client/register-my-client[snippets="http-request,request-headers,request-fields,http-response,response-fields-data"]

--- a/src/main/java/es/princip/getp/domain/client/command/application/ClientService.java
+++ b/src/main/java/es/princip/getp/domain/client/command/application/ClientService.java
@@ -1,6 +1,6 @@
 package es.princip.getp.domain.client.command.application;
 
-import es.princip.getp.domain.client.command.application.command.CreateClientCommand;
+import es.princip.getp.domain.client.command.application.command.RegisterClientCommand;
 import es.princip.getp.domain.client.command.application.command.UpdateClientCommand;
 import es.princip.getp.domain.client.command.domain.Client;
 import es.princip.getp.domain.client.command.domain.ClientRepository;
@@ -24,7 +24,7 @@ public class ClientService {
     private final ClientRepository clientRepository;
 
     @Transactional
-    public Long create(CreateClientCommand command) {
+    public Long registerClient(RegisterClientCommand command) {
         if (clientRepository.existsByMemberId(command.memberId())) {
             throw new BusinessLogicException(ClientErrorCode.ALREADY_EXIST);
         }

--- a/src/main/java/es/princip/getp/domain/client/command/application/command/RegisterClientCommand.java
+++ b/src/main/java/es/princip/getp/domain/client/command/application/command/RegisterClientCommand.java
@@ -6,7 +6,7 @@ import es.princip.getp.domain.member.command.domain.model.Email;
 import es.princip.getp.domain.member.command.domain.model.Nickname;
 import es.princip.getp.domain.member.command.domain.model.PhoneNumber;
 
-public record CreateClientCommand(
+public record RegisterClientCommand(
     Long memberId,
     Nickname nickname,
     Email email, // 미입력 시 회원 가입 시 작성한 이메일 주소가 기본값

--- a/src/main/java/es/princip/getp/domain/client/command/presentation/MyClientController.java
+++ b/src/main/java/es/princip/getp/domain/client/command/presentation/MyClientController.java
@@ -1,9 +1,9 @@
 package es.princip.getp.domain.client.command.presentation;
 
 import es.princip.getp.domain.client.command.application.ClientService;
-import es.princip.getp.domain.client.command.application.command.CreateClientCommand;
+import es.princip.getp.domain.client.command.application.command.RegisterClientCommand;
 import es.princip.getp.domain.client.command.application.command.UpdateClientCommand;
-import es.princip.getp.domain.client.command.presentation.dto.request.CreateClientRequest;
+import es.princip.getp.domain.client.command.presentation.dto.request.RegisterMyClientRequest;
 import es.princip.getp.domain.client.command.presentation.dto.request.UpdateClientRequest;
 import es.princip.getp.domain.client.command.presentation.dto.response.CreateClientResponse;
 import es.princip.getp.infra.dto.response.ApiResponse;
@@ -31,12 +31,12 @@ public class MyClientController {
      */
     @PostMapping
     @PreAuthorize("hasRole('CLIENT') and isAuthenticated()")
-    public ResponseEntity<ApiSuccessResult<CreateClientResponse>> create(
-        @RequestBody @Valid final CreateClientRequest request,
+    public ResponseEntity<ApiSuccessResult<CreateClientResponse>> registerMyClient(
+        @RequestBody @Valid final RegisterMyClientRequest request,
         @AuthenticationPrincipal final PrincipalDetails principalDetails) {
         final Long memberId = principalDetails.getMember().getMemberId();
-        final CreateClientCommand command = request.toCommand(memberId);
-        final Long clientId = clientService.create(command);
+        final RegisterClientCommand command = request.toCommand(memberId);
+        final Long clientId = clientService.registerClient(command);
         final CreateClientResponse response = new CreateClientResponse(clientId);
         return ApiResponse.success(HttpStatus.CREATED, response);
     }

--- a/src/main/java/es/princip/getp/domain/client/command/presentation/dto/request/RegisterMyClientRequest.java
+++ b/src/main/java/es/princip/getp/domain/client/command/presentation/dto/request/RegisterMyClientRequest.java
@@ -1,6 +1,6 @@
 package es.princip.getp.domain.client.command.presentation.dto.request;
 
-import es.princip.getp.domain.client.command.application.command.CreateClientCommand;
+import es.princip.getp.domain.client.command.application.command.RegisterClientCommand;
 import es.princip.getp.domain.client.command.domain.Address;
 import es.princip.getp.domain.client.command.domain.BankAccount;
 import es.princip.getp.domain.member.command.domain.model.Email;
@@ -9,7 +9,7 @@ import es.princip.getp.domain.member.command.domain.model.PhoneNumber;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 
-public record CreateClientRequest(
+public record RegisterMyClientRequest(
     @NotBlank String nickname, // 필수
     String email, // 선택, 미입력 시 회원 가입 시 작성한 이메일 주소가 기본값
     @NotBlank String phoneNumber, // 필수
@@ -17,8 +17,8 @@ public record CreateClientRequest(
     @Valid BankAccount bankAccount // 선택
 ) {
 
-    public CreateClientCommand toCommand(final Long memberId) {
-        return new CreateClientCommand(
+    public RegisterClientCommand toCommand(final Long memberId) {
+        return new RegisterClientCommand(
             memberId,
             Nickname.of(nickname()),
             email() == null ? null : Email.of(email()),

--- a/src/main/java/es/princip/getp/domain/member/command/application/command/UpdateMemberCommand.java
+++ b/src/main/java/es/princip/getp/domain/member/command/application/command/UpdateMemberCommand.java
@@ -1,6 +1,6 @@
 package es.princip.getp.domain.member.command.application.command;
 
-import es.princip.getp.domain.client.command.application.command.CreateClientCommand;
+import es.princip.getp.domain.client.command.application.command.RegisterClientCommand;
 import es.princip.getp.domain.client.command.application.command.UpdateClientCommand;
 import es.princip.getp.domain.member.command.domain.model.Nickname;
 import es.princip.getp.domain.member.command.domain.model.PhoneNumber;
@@ -28,7 +28,7 @@ public record UpdateMemberCommand(
         );
     }
 
-    public static UpdateMemberCommand from(final CreateClientCommand command) {
+    public static UpdateMemberCommand from(final RegisterClientCommand command) {
         return new UpdateMemberCommand(
             command.memberId(),
             command.nickname(),

--- a/src/test/java/es/princip/getp/domain/client/command/application/ClientServiceTest.java
+++ b/src/test/java/es/princip/getp/domain/client/command/application/ClientServiceTest.java
@@ -1,6 +1,6 @@
 package es.princip.getp.domain.client.command.application;
 
-import es.princip.getp.domain.client.command.application.command.CreateClientCommand;
+import es.princip.getp.domain.client.command.application.command.RegisterClientCommand;
 import es.princip.getp.domain.client.command.application.command.UpdateClientCommand;
 import es.princip.getp.domain.client.command.domain.Client;
 import es.princip.getp.domain.client.command.domain.ClientRepository;
@@ -46,16 +46,16 @@ public class ClientServiceTest {
     private ClientRepository clientRepository;
 
     @Nested
-    @DisplayName("create()는")
-    class Create {
+    @DisplayName("registerClient()는")
+    class RegisterClient {
 
         private final Long clientId = 1L;
         private final Long memberId = 1L;
 
         @Test
         @DisplayName("의뢰자 정보를 등록한다.")
-        void create() {
-            final CreateClientCommand command = new CreateClientCommand(
+        void registerClient() {
+            final RegisterClientCommand command = new RegisterClientCommand(
                 memberId,
                 nickname(),
                 email(),
@@ -69,15 +69,15 @@ public class ClientServiceTest {
             willDoNothing().given(memberService).update(eq(UpdateMemberCommand.from(command)));
             given(clientRepository.save(any(Client.class))).willReturn(client);
 
-            final Long clientId = clientService.create(command);
+            final Long clientId = clientService.registerClient(command);
 
             assertThat(clientId).isEqualTo(this.clientId);
         }
 
         @Test
         @DisplayName("이메일이 입력되지 않은 경우 회원 정보의 이메일 주소를 사용한다.")
-        void create_WhenEmailIsNull_UseEmailOfMember() {
-            final CreateClientCommand command = new CreateClientCommand(
+        void registerClient_WhenEmailIsNull_UseEmailOfMember() {
+            final RegisterClientCommand command = new RegisterClientCommand(
                 memberId,
                 nickname(),
                 null,
@@ -94,7 +94,7 @@ public class ClientServiceTest {
             given(memberRepository.findById(command.memberId())).willReturn(Optional.of(member));
             given(clientRepository.save(any(Client.class))).willReturn(client);
 
-            final Long clientId = clientService.create(command);
+            final Long clientId = clientService.registerClient(command);
 
             assertThat(clientId).isEqualTo(this.clientId);
         }

--- a/src/test/java/es/princip/getp/domain/client/command/presentation/MyClientControllerTest.java
+++ b/src/test/java/es/princip/getp/domain/client/command/presentation/MyClientControllerTest.java
@@ -1,6 +1,7 @@
 package es.princip.getp.domain.client.command.presentation;
 
 import es.princip.getp.domain.client.command.application.ClientService;
+import es.princip.getp.domain.client.command.presentation.description.RegisterMyClientRequestDescription;
 import es.princip.getp.domain.client.command.presentation.dto.request.RegisterMyClientRequest;
 import es.princip.getp.domain.client.command.presentation.dto.request.UpdateClientRequest;
 import es.princip.getp.domain.client.exception.ClientErrorCode;
@@ -27,6 +28,7 @@ import static es.princip.getp.infra.util.PayloadDocumentationHelper.responseFiel
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -70,6 +72,7 @@ class MyClientControllerTest extends AbstractControllerTest {
                 .andDo(
                     restDocs.document(
                         requestHeaders(authorizationHeaderDescriptor()),
+                        requestFields(RegisterMyClientRequestDescription.description()),
                         responseFields(
                            getDescriptor("clientId", "등록된 의뢰자 ID")
                         )

--- a/src/test/java/es/princip/getp/domain/client/command/presentation/MyClientControllerTest.java
+++ b/src/test/java/es/princip/getp/domain/client/command/presentation/MyClientControllerTest.java
@@ -1,7 +1,7 @@
 package es.princip.getp.domain.client.command.presentation;
 
 import es.princip.getp.domain.client.command.application.ClientService;
-import es.princip.getp.domain.client.command.presentation.dto.request.CreateClientRequest;
+import es.princip.getp.domain.client.command.presentation.dto.request.RegisterMyClientRequest;
 import es.princip.getp.domain.client.command.presentation.dto.request.UpdateClientRequest;
 import es.princip.getp.domain.client.exception.ClientErrorCode;
 import es.princip.getp.domain.member.command.domain.model.MemberType;
@@ -14,14 +14,19 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
 
 import static es.princip.getp.domain.client.fixture.AddressFixture.address;
 import static es.princip.getp.domain.client.fixture.BankAccountFixture.bankAccount;
 import static es.princip.getp.domain.member.fixture.EmailFixture.EMAIL;
 import static es.princip.getp.domain.member.fixture.NicknameFixture.NICKNAME;
 import static es.princip.getp.domain.member.fixture.PhoneNumberFixture.PHONE_NUMBER;
+import static es.princip.getp.infra.util.FieldDescriptorHelper.getDescriptor;
+import static es.princip.getp.infra.util.HeaderDescriptorHelper.authorizationHeaderDescriptor;
+import static es.princip.getp.infra.util.PayloadDocumentationHelper.responseFields;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -35,26 +40,41 @@ class MyClientControllerTest extends AbstractControllerTest {
 
     @Nested
     @DisplayName("내 의뢰자 정보 등록")
-    class Create {
+    class RegisterMyClient {
+
+        final RegisterMyClientRequest request = new RegisterMyClientRequest(
+            NICKNAME,
+            EMAIL,
+            PHONE_NUMBER,
+            address(),
+            bankAccount()
+        );
+        final Long clientId = 1L;
+        final Long memberId = 1L;
+
+        private ResultActions perform() throws Exception {
+            return mockMvc.perform(post(REQUEST_URI)
+                .header("Authorization", "Bearer ${ACCESS_TOKEN}")
+                .content(objectMapper.writeValueAsString(request)));
+        }
 
         @Test
         @DisplayName("의뢰자는 의뢰자 정보를 등록할 수 있다.")
         @WithCustomMockUser(memberType = MemberType.ROLE_CLIENT)
-        void create(final PrincipalDetails principalDetails) throws Exception {
-            final CreateClientRequest request = new CreateClientRequest(
-                NICKNAME,
-                EMAIL,
-                PHONE_NUMBER,
-                address(),
-                bankAccount()
-            );
-            final Long memberId = principalDetails.getMember().getMemberId();
-            final Long clientId = 1L;
-            given(clientService.create(eq(request.toCommand(memberId)))).willReturn(clientId);
+        void registerMyClient() throws Exception {
+            given(clientService.registerClient(eq(request.toCommand(memberId))))
+                .willReturn(clientId);
 
-            mockMvc.perform(post(REQUEST_URI)
-                .content(objectMapper.writeValueAsString(request)))
+            perform()
                 .andExpect(status().isCreated())
+                .andDo(
+                    restDocs.document(
+                        requestHeaders(authorizationHeaderDescriptor()),
+                        responseFields(
+                           getDescriptor("clientId", "등록된 의뢰자 ID")
+                        )
+                    )
+                )
                 .andDo(print());
         }
     }

--- a/src/test/java/es/princip/getp/domain/client/command/presentation/description/RegisterMyClientRequestDescription.java
+++ b/src/test/java/es/princip/getp/domain/client/command/presentation/description/RegisterMyClientRequestDescription.java
@@ -1,0 +1,24 @@
+package es.princip.getp.domain.client.command.presentation.description;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+import static es.princip.getp.infra.util.FieldDescriptorHelper.getDescriptor;
+
+public class RegisterMyClientRequestDescription {
+
+    public static FieldDescriptor[] description() {
+        final Class<?> clazz = RegisterMyClientRequestDescription.class;
+        return new FieldDescriptor[] {
+            getDescriptor("nickname", "닉네임", clazz),
+            getDescriptor("email", "이메일(기본값은 회원 가입 시 기입한 이메일)", clazz)
+                .optional(),
+            getDescriptor("phoneNumber", "전화번호", clazz),
+            getDescriptor("address.zipcode", "우편번호"),
+            getDescriptor("address.street", "도로명"),
+            getDescriptor("address.detail", "상세 주소"),
+            getDescriptor("bankAccount.bank", "은행명"),
+            getDescriptor("bankAccount.accountNumber", "계좌번호"),
+            getDescriptor("bankAccount.accountHolder", "예금주")
+        };
+    }
+}


### PR DESCRIPTION
## ✨ 구현한 기능
- 의뢰자 정보 등록 컨트롤러 단위 테스트 작성

## 📢 논의하고 싶은 내용
- 도메인 모델에서 다음 행위에 대한 명칭을 이와 같이 통일하려고 합니다. 단순히 Create, Update라고 명칭하는 것 보다는 더 비즈니스 적인 의미가 담기도록 하는 것이 좋을 것 같습니다.
  - 등록하다: Register
  - 수정하다: Edit

## 🎸 기타
- 