### PR TITLE
GETP-166 feat: 프로젝트 상세 조회 기능의 프로젝트 좋아요 수 조회 구현

### DIFF
--- a/src/main/java/es/princip/getp/domain/people/command/domain/People.java
+++ b/src/main/java/es/princip/getp/domain/people/command/domain/People.java
@@ -2,8 +2,6 @@ package es.princip.getp.domain.people.command.domain;
 
 import es.princip.getp.domain.common.domain.BaseTimeEntity;
 import es.princip.getp.domain.member.command.domain.model.Email;
-import es.princip.getp.domain.people.exception.ProjectAlreadyLikedException;
-import es.princip.getp.domain.people.exception.ProjectNeverLikedException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -11,10 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 
 @Entity
 @Table(name = "people")
@@ -40,13 +35,6 @@ public class People extends BaseTimeEntity {
     @NotNull
     private Long memberId;
 
-    @ElementCollection
-    @CollectionTable(
-        name = "people_project_like",
-        joinColumns = @JoinColumn(name = "people_id")
-    )
-    private Set<Long> likedProjects = new HashSet<>();
-
     @Builder
     public People(
         final Email email,
@@ -56,10 +44,6 @@ public class People extends BaseTimeEntity {
         this.email = email;
         this.peopleType = peopleType;
         this.memberId = memberId;
-    }
-
-    public Set<Long> getLikedProjects() {
-        return Collections.unmodifiableSet(likedProjects);
     }
 
     private void setEmail(final Email email) {
@@ -84,39 +68,5 @@ public class People extends BaseTimeEntity {
     ) {
         setEmail(email);
         setPeopleType(peopleType);
-    }
-
-    private boolean alreadyLikedProject(final Long projectId) {
-        return likedProjects.contains(projectId);
-    }
-
-    private boolean neverLikedProject(final Long projectId) {
-        return !likedProjects.contains(projectId);
-    }
-
-    /**
-     * 프로젝트에게 좋아요를 누른다.
-     *
-     * @param projectId 좋아요할 프로젝트 ID
-     * @throws ProjectAlreadyLikedException 이미 좋아요한 프로젝트일 경우
-     */
-    public void likeProject(final Long projectId) {
-        if (alreadyLikedProject(projectId)) {
-            throw new ProjectAlreadyLikedException();
-        }
-        likedProjects.add(projectId);
-    }
-
-    /**
-     * 프로젝트에게 눌렀던 좋아요를 취소한다.
-     *
-     * @param projectId 좋아요를 취소할 프로젝트 ID
-     * @throws ProjectNeverLikedException 좋아요한 적이 없었던 경우
-     */
-    public void unlikeProject(final Long projectId) {
-        if (neverLikedProject(projectId)) {
-            throw new ProjectNeverLikedException();
-        }
-        likedProjects.remove(projectId);
     }
 }

--- a/src/main/java/es/princip/getp/domain/project/command/application/ProjectLikeService.java
+++ b/src/main/java/es/princip/getp/domain/project/command/application/ProjectLikeService.java
@@ -2,7 +2,7 @@ package es.princip.getp.domain.project.command.application;
 
 import es.princip.getp.domain.people.command.domain.People;
 import es.princip.getp.domain.people.command.domain.PeopleRepository;
-import es.princip.getp.domain.project.command.domain.ProjectRepository;
+import es.princip.getp.domain.project.command.domain.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +15,10 @@ public class ProjectLikeService {
 
     private final ProjectRepository projectRepository;
     private final PeopleRepository peopleRepository;
+    private final ProjectLikeRepository projectLikeRepository;
+
+    private final ProjectLiker projectLiker;
+    private final ProjectUnliker projectUnliker;
 
     /**
      * 프로젝트 좋아요
@@ -24,11 +28,14 @@ public class ProjectLikeService {
      */
     @Transactional
     public void like(final Long memberId, final Long projectId) {
-        if (!projectRepository.existsById(projectId)) {
-            throw new EntityNotFoundException("해당 프로젝트가 존재하지 않습니다.");
-        }
-        final People people = peopleRepository.findByMemberId(memberId).orElseThrow();
-        people.likeProject(projectId);
+        final People people = peopleRepository.findById(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 피플을 찾을 수 없습니다."));
+        final Project project = projectRepository.findById(projectId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 프로젝트를 찾을 수 없습니다."));
+
+        final ProjectLike like = projectLiker.like(people, project);
+
+        projectLikeRepository.save(like);
     }
 
     /**
@@ -39,10 +46,11 @@ public class ProjectLikeService {
      */
     @Transactional
     public void unlike(final Long memberId, final Long projectId) {
-        if (!projectRepository.existsById(projectId)) {
-            throw new EntityNotFoundException("해당 프로젝트가 존재하지 않습니다.");
-        }
-        final People people = peopleRepository.findByMemberId(memberId).orElseThrow();
-        people.unlikeProject(projectId);
+        final People people = peopleRepository.findById(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 피플을 찾을 수 없습니다."));
+        final Project project = projectRepository.findById(projectId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 프로젝트를 찾을 수 없습니다."));
+
+        projectUnliker.unlike(people, project);
     }
 }

--- a/src/main/java/es/princip/getp/domain/project/command/domain/ProjectLike.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/ProjectLike.java
@@ -1,0 +1,34 @@
+package es.princip.getp.domain.project.command.domain;
+
+import es.princip.getp.domain.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "project_like")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "project_like_id")
+    private Long id;
+
+    @Column(name = "people_id")
+    private Long peopleId;
+
+    @Column(name = "project_id")
+    private Long projectId;
+
+    private ProjectLike(final Long peopleId, final Long projectId) {
+        this.peopleId = peopleId;
+        this.projectId = projectId;
+    }
+
+    public static ProjectLike of(final Long peopleId, final Long projectId) {
+        return new ProjectLike(peopleId, projectId);
+    }
+}

--- a/src/main/java/es/princip/getp/domain/project/command/domain/ProjectLikeRepository.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/ProjectLikeRepository.java
@@ -1,0 +1,12 @@
+package es.princip.getp.domain.project.command.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectLikeRepository extends JpaRepository<ProjectLike, Long> {
+
+    boolean existsByPeopleIdAndProjectId(Long peopleId, Long projectId);
+
+    void deleteByPeopleIdAndProjectId(Long peopleId, Long projectId);
+}

--- a/src/main/java/es/princip/getp/domain/project/command/domain/ProjectLiker.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/ProjectLiker.java
@@ -1,0 +1,36 @@
+package es.princip.getp.domain.project.command.domain;
+
+import es.princip.getp.domain.people.command.domain.People;
+import es.princip.getp.domain.project.exception.ProjectAlreadyLikedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectLiker {
+
+    private final ProjectLikeRepository projectLikeRepository;
+
+    private void checkProjectAlreadyLiked(final Long peopleId, final Long projectId) {
+        if (projectLikeRepository.existsByPeopleIdAndProjectId(peopleId, projectId)) {
+            throw new ProjectAlreadyLikedException();
+        }
+    }
+
+    /**
+     * 프로젝트에 좋아요를 누른다.
+     *
+     * @param people 좋아요를 누르는 피플
+     * @param project 좋아요를 누를 프로젝트
+     * @return 좋아요 이력
+     * @throws ProjectAlreadyLikedException 이미 해당 프로젝트에 좋아요를 눌렀던 경우
+     */
+    public ProjectLike like(final People people, final Project project) {
+        final Long peopleId = people.getPeopleId();
+        final Long projectId = project.getProjectId();
+
+        checkProjectAlreadyLiked(peopleId, projectId);
+
+        return ProjectLike.of(peopleId, projectId);
+    }
+}

--- a/src/main/java/es/princip/getp/domain/project/command/domain/ProjectUnliker.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/ProjectUnliker.java
@@ -1,0 +1,35 @@
+package es.princip.getp.domain.project.command.domain;
+
+import es.princip.getp.domain.people.command.domain.People;
+import es.princip.getp.domain.project.exception.ProjectNeverLikedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectUnliker {
+
+    private final ProjectLikeRepository projectLikeRepository;
+
+    private void checkProjectNeverLiked(final Long peopleId, final Long projectId) {
+        if (!projectLikeRepository.existsByPeopleIdAndProjectId(peopleId, projectId)) {
+            throw new ProjectNeverLikedException();
+        }
+    }
+
+    /**
+     * 프로젝트에 눌렀던 좋아요를 취소한다.
+     *
+     * @param people 좋아요를 취소하는 피플
+     * @param project 좋아요를 취소할 프로젝트
+     * @throws ProjectNeverLikedException 프로젝트에 좋아요를 누른 적이 없는 경우
+     */
+    public void unlike(final People people, final Project project) {
+        final Long peopleId = people.getPeopleId();
+        final Long projectId = project.getProjectId();
+
+        checkProjectNeverLiked(peopleId, projectId);
+
+        projectLikeRepository.deleteByPeopleIdAndProjectId(peopleId, projectId);
+    }
+}

--- a/src/main/java/es/princip/getp/domain/project/exception/ProjectAlreadyLikedException.java
+++ b/src/main/java/es/princip/getp/domain/project/exception/ProjectAlreadyLikedException.java
@@ -1,10 +1,10 @@
-package es.princip.getp.domain.people.exception;
+package es.princip.getp.domain.project.exception;
 
 import es.princip.getp.infra.exception.BusinessLogicException;
 
 public class ProjectAlreadyLikedException extends BusinessLogicException {
 
     public ProjectAlreadyLikedException() {
-        super("이미 좋아요한 프로젝트입니다.");
+        super("이미 좋아요를 누른 프로젝트입니다.");
     }
 }

--- a/src/main/java/es/princip/getp/domain/project/exception/ProjectNeverLikedException.java
+++ b/src/main/java/es/princip/getp/domain/project/exception/ProjectNeverLikedException.java
@@ -1,4 +1,4 @@
-package es.princip.getp.domain.people.exception;
+package es.princip.getp.domain.project.exception;
 
 import es.princip.getp.infra.exception.BusinessLogicException;
 

--- a/src/main/java/es/princip/getp/domain/project/query/dao/ProjectLikeDao.java
+++ b/src/main/java/es/princip/getp/domain/project/query/dao/ProjectLikeDao.java
@@ -1,0 +1,6 @@
+package es.princip.getp.domain.project.query.dao;
+
+public interface ProjectLikeDao {
+
+    Long countByProjectId(Long projectId);
+}

--- a/src/main/java/es/princip/getp/domain/project/query/dao/ProjectLikeQueryDslDao.java
+++ b/src/main/java/es/princip/getp/domain/project/query/dao/ProjectLikeQueryDslDao.java
@@ -1,0 +1,18 @@
+package es.princip.getp.domain.project.query.dao;
+
+import es.princip.getp.infra.support.QueryDslSupport;
+import org.springframework.stereotype.Repository;
+
+import static es.princip.getp.domain.project.command.domain.QProjectLike.projectLike;
+
+@Repository
+public class ProjectLikeQueryDslDao extends QueryDslSupport implements ProjectLikeDao {
+
+    // TODO: 좋아요 수 조회 성능 개선 필요
+    public Long countByProjectId(final Long projectId) {
+        return queryFactory.select(projectLike.count())
+            .from(projectLike)
+            .where(projectLike.projectId.eq(projectId))
+            .fetchOne();
+    }
+}

--- a/src/main/java/es/princip/getp/domain/project/query/dao/ProjectQueryDslDao.java
+++ b/src/main/java/es/princip/getp/domain/project/query/dao/ProjectQueryDslDao.java
@@ -27,6 +27,7 @@ import static es.princip.getp.domain.project.query.dao.ProjectDaoHelper.toProjec
 @RequiredArgsConstructor
 public class ProjectQueryDslDao extends QueryDslSupport implements ProjectDao {
 
+    private final ProjectLikeDao projectLikeDao;
     private final ProjectApplicationDao projectApplicationDao;
 
     private List<Project> getProjects(Pageable pageable) {
@@ -87,6 +88,7 @@ public class ProjectQueryDslDao extends QueryDslSupport implements ProjectDao {
                 .fetchOne()
             )
             .orElseThrow(() -> new EntityNotFoundException("해당 프로젝트가 존재하지 않습니다."));
+        final Long likesCount = projectLikeDao.countByProjectId(projectId);
 
         return new ProjectDetailResponse(
             result.getProjectId(),
@@ -100,7 +102,7 @@ public class ProjectQueryDslDao extends QueryDslSupport implements ProjectDao {
             result.getStatus(),
             AttachmentFilesResponse.from(result.getAttachmentFiles()),
             HashtagsResponse.from(result.getHashtags()),
-            0L,
+            likesCount,
             getProjectClientResponseByClientId(result.getClientId())
         );
     }

--- a/src/main/java/es/princip/getp/domain/project/query/dto/ProjectDetailResponse.java
+++ b/src/main/java/es/princip/getp/domain/project/query/dto/ProjectDetailResponse.java
@@ -18,7 +18,7 @@ public record ProjectDetailResponse(
     ProjectStatus status,
     AttachmentFilesResponse attachmentFiles,
     HashtagsResponse hashtags,
-    Long interestCount,
+    Long likesCount,
     ProjectClientResponse client
 ) {
 }

--- a/src/test/java/es/princip/getp/domain/people/command/domain/PeopleTest.java
+++ b/src/test/java/es/princip/getp/domain/people/command/domain/PeopleTest.java
@@ -1,79 +1,7 @@
 package es.princip.getp.domain.people.command.domain;
 
-import es.princip.getp.domain.people.exception.ProjectAlreadyLikedException;
-import es.princip.getp.domain.people.exception.ProjectNeverLikedException;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import static es.princip.getp.domain.member.fixture.EmailFixture.email;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("피플")
 class PeopleTest {
-
-    @Nested
-    class 프로젝트_좋아요 {
-
-        @Test
-        void 피플은_프로젝트에_좋아요를_누를_수_있다() {
-            final People people = People.builder()
-                .email(email())
-                .peopleType(PeopleType.INDIVIDUAL)
-                .memberId(1L)
-                .build();
-            final Long projectId = 1L;
-
-            people.likeProject(projectId);
-
-            assertThat(people.getLikedProjects()).contains(projectId);
-        }
-
-        @Test
-        void 피플은_프로젝트에_좋아요를_중복으로_누를_수_없다() {
-            final People people = People.builder()
-                .email(email())
-                .peopleType(PeopleType.INDIVIDUAL)
-                .memberId(1L)
-                .build();
-            final Long projectId = 1L;
-            people.likeProject(projectId);
-
-            assertThatThrownBy(() -> people.likeProject(projectId))
-                .isInstanceOf(ProjectAlreadyLikedException.class);
-        }
-    }
-
-    @Nested
-    class 프로젝트_좋아요_취소 {
-
-        @Test
-        void 피플은_프로젝트에_눌렀던_좋아요를_취소할_수_있다() {
-            final People people = People.builder()
-                .email(email())
-                .peopleType(PeopleType.INDIVIDUAL)
-                .memberId(1L)
-                .build();
-            final Long projectId = 1L;
-            people.likeProject(projectId);
-
-            people.unlikeProject(projectId);
-
-            assertThat(people.getLikedProjects()).doesNotContain(projectId);
-        }
-
-        @Test
-        void 피플은_좋아요를_누른적이_없는_프로젝트에_좋아요를_취소할_수_없다() {
-            final People people = People.builder()
-                .email(email())
-                .peopleType(PeopleType.INDIVIDUAL)
-                .memberId(1L)
-                .build();
-            final Long projectId = 1L;
-
-            assertThatThrownBy(() -> people.unlikeProject(projectId))
-                .isInstanceOf(ProjectNeverLikedException.class);
-        }
-    }
 }

--- a/src/test/java/es/princip/getp/domain/people/command/presentation/PeopleLikeControllerTest.java
+++ b/src/test/java/es/princip/getp/domain/people/command/presentation/PeopleLikeControllerTest.java
@@ -2,7 +2,7 @@ package es.princip.getp.domain.people.command.presentation;
 
 import es.princip.getp.domain.member.command.domain.model.MemberType;
 import es.princip.getp.domain.people.command.application.PeopleLikeService;
-import es.princip.getp.domain.people.exception.ProjectAlreadyLikedException;
+import es.princip.getp.domain.project.exception.ProjectAlreadyLikedException;
 import es.princip.getp.infra.annotation.WithCustomMockUser;
 import es.princip.getp.infra.support.AbstractControllerTest;
 import jakarta.persistence.EntityNotFoundException;
@@ -18,7 +18,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PeopleLikeController.class)

--- a/src/test/java/es/princip/getp/domain/project/command/domain/ProjectLikerTest.java
+++ b/src/test/java/es/princip/getp/domain/project/command/domain/ProjectLikerTest.java
@@ -1,0 +1,56 @@
+package es.princip.getp.domain.project.command.domain;
+
+import es.princip.getp.domain.people.command.domain.People;
+import es.princip.getp.domain.project.exception.ProjectAlreadyLikedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectLikerTest {
+
+    @Mock
+    private ProjectLikeRepository projectLikeRepository;
+
+    @InjectMocks
+    private ProjectLiker projectLiker;
+
+    private final Long peopleId = 1L;
+    private final Long projectId = 1L;
+
+    private final People people = mock(People.class);
+    private final Project project = mock(Project.class);
+
+    @BeforeEach
+    void setUp() {
+        given(people.getPeopleId()).willReturn(peopleId);
+        given(project.getProjectId()).willReturn(projectId);
+    }
+
+    @Test
+    void 피플은_프로젝트에_좋아요를_누를_수_있다() {
+        given(projectLikeRepository.existsByPeopleIdAndProjectId(peopleId, projectId))
+            .willReturn(false);
+
+        ProjectLike like = projectLiker.like(people, project);
+
+        assertThat(like).isNotNull();
+    }
+
+    @Test
+    void 피플은_프로젝트에_좋아요를_중복으로_누를_수_없다() {
+        given(projectLikeRepository.existsByPeopleIdAndProjectId(peopleId, projectId))
+            .willReturn(true);
+
+        assertThatThrownBy(() -> projectLiker.like(people, project))
+            .isInstanceOf(ProjectAlreadyLikedException.class);
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/command/domain/ProjectUnlikerTest.java
+++ b/src/test/java/es/princip/getp/domain/project/command/domain/ProjectUnlikerTest.java
@@ -1,0 +1,55 @@
+package es.princip.getp.domain.project.command.domain;
+
+import es.princip.getp.domain.people.command.domain.People;
+import es.princip.getp.domain.project.exception.ProjectNeverLikedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectUnlikerTest {
+
+    @Mock
+    private ProjectLikeRepository projectLikeRepository;
+
+    @InjectMocks
+    private ProjectUnliker projectUnliker;
+
+    private final Long peopleId = 1L;
+    private final Long projectId = 1L;
+
+    private final People people = mock(People.class);
+    private final Project project = mock(Project.class);
+
+    @BeforeEach
+    void setUp() {
+        given(people.getPeopleId()).willReturn(peopleId);
+        given(project.getProjectId()).willReturn(projectId);
+    }
+
+    @Test
+    void 피플은_프로젝트에_눌렀던_좋아요를_취소할_수_있다() {
+        given(projectLikeRepository.existsByPeopleIdAndProjectId(peopleId, projectId))
+            .willReturn(true);
+
+        assertThatCode(() -> projectUnliker.unlike(people, project))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 피플은_좋아요를_누른적이_없는_프로젝트에_좋아요를_취소할_수_없다() {
+        given(projectLikeRepository.existsByPeopleIdAndProjectId(peopleId, projectId))
+            .willReturn(false);
+
+        assertThatThrownBy(() -> projectUnliker.unlike(people, project))
+            .isInstanceOf(ProjectNeverLikedException.class);
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/query/dao/ProjectLikeDaoTest.java
+++ b/src/test/java/es/princip/getp/domain/project/query/dao/ProjectLikeDaoTest.java
@@ -1,0 +1,30 @@
+package es.princip.getp.domain.project.query.dao;
+
+import es.princip.getp.domain.project.query.infra.ProjectLikeDaoConfig;
+import es.princip.getp.infra.support.DaoTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@Slf4j
+@Import(ProjectLikeDaoConfig.class)
+class ProjectLikeDaoTest extends DaoTest {
+
+    public ProjectLikeDaoTest() {
+        super(10);
+    }
+
+    @Autowired
+    private ProjectLikeDao projectLikeDao;
+
+    @Test
+    void countByProjectId() {
+        final Long likesCount = projectLikeDao.countByProjectId(1L);
+
+        assertThat(likesCount).isEqualTo(TEST_SIZE);
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/query/infra/ProjectDaoConfig.java
+++ b/src/test/java/es/princip/getp/domain/project/query/infra/ProjectDaoConfig.java
@@ -2,6 +2,7 @@ package es.princip.getp.domain.project.query.infra;
 
 import es.princip.getp.domain.project.query.dao.ProjectApplicationDao;
 import es.princip.getp.domain.project.query.dao.ProjectDao;
+import es.princip.getp.domain.project.query.dao.ProjectLikeDao;
 import es.princip.getp.domain.project.query.dao.ProjectQueryDslDao;
 import es.princip.getp.infra.DataLoader;
 import jakarta.persistence.EntityManager;
@@ -12,18 +13,21 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 @TestConfiguration
-@Import(ProjectApplicationDaoConfig.class)
+@Import({ProjectApplicationDaoConfig.class, ProjectLikeDaoConfig.class})
 public class ProjectDaoConfig {
 
     @PersistenceContext
     private EntityManager entityManager;
 
     @Autowired
+    private ProjectLikeDao projectLikeDao;
+
+    @Autowired
     private ProjectApplicationDao projectApplicationDao;
 
     @Bean
     public ProjectDao projectDao() {
-        return new ProjectQueryDslDao(projectApplicationDao);
+        return new ProjectQueryDslDao(projectLikeDao, projectApplicationDao);
     }
 
     @Bean

--- a/src/test/java/es/princip/getp/domain/project/query/infra/ProjectLikeDaoConfig.java
+++ b/src/test/java/es/princip/getp/domain/project/query/infra/ProjectLikeDaoConfig.java
@@ -1,0 +1,26 @@
+package es.princip.getp.domain.project.query.infra;
+
+import es.princip.getp.domain.project.query.dao.ProjectLikeDao;
+import es.princip.getp.domain.project.query.dao.ProjectLikeQueryDslDao;
+import es.princip.getp.infra.DataLoader;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class ProjectLikeDaoConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public ProjectLikeDao projectLikeDao() {
+        return new ProjectLikeQueryDslDao();
+    }
+
+    @Bean
+    public DataLoader projectLikeDataLoader() {
+        return new ProjectLikeDataLoader(entityManager);
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/query/infra/ProjectLikeDataLoader.java
+++ b/src/test/java/es/princip/getp/domain/project/query/infra/ProjectLikeDataLoader.java
@@ -1,0 +1,33 @@
+package es.princip.getp.domain.project.query.infra;
+
+import es.princip.getp.domain.project.command.domain.ProjectLike;
+import es.princip.getp.infra.DataLoader;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.LongStream;
+
+@RequiredArgsConstructor
+public class ProjectLikeDataLoader implements DataLoader {
+
+    private final EntityManager entityManager;
+
+    @Transactional
+    @Override
+    public void load(final int size) {
+        loadProjectLike(size);
+    }
+
+    private void loadProjectLike(final int size) {
+        final List<ProjectLike> projectLikeList = new ArrayList<>();
+        LongStream.rangeClosed(1, size).forEach(projectId ->
+            LongStream.rangeClosed(1, size).forEach(peopleId ->
+                projectLikeList.add(ProjectLike.of(peopleId, projectId))
+            )
+        );
+        projectLikeList.forEach(entityManager::persist);
+    }
+}

--- a/src/test/java/es/princip/getp/domain/project/query/presentation/description/ProjectDetailResponseDescription.java
+++ b/src/test/java/es/princip/getp/domain/project/query/presentation/description/ProjectDetailResponseDescription.java
@@ -21,7 +21,7 @@ public class ProjectDetailResponseDescription {
             getDescriptor("status", "프로젝트 상태"),
             getDescriptor("attachmentFiles[]", "첨부 파일 목록"),
             getDescriptor("hashtags[]", "해시태그"),
-            getDescriptor("interestCount", "프로젝트 관심 수"),
+            getDescriptor("likesCount", "프로젝트 좋아요 수"),
             getDescriptor("client.clientId", "의뢰자 ID"),
             getDescriptor("client.nickname", "의뢰자 닉네임"),
             getDescriptor("client.address.zipcode", "의뢰자 우편번호"),


### PR DESCRIPTION
## ✨ 구현한 기능
- 프로젝트 상세 조회 기능의 프로젝트 좋아요 수 조회 구현

## 📢 논의하고 싶은 내용
- 현재 해당 기능은 프로젝트 ID에 해당하는 좋아요 이력을 조회하여 총 좋아요 개수를 구하고 있습니다. 이는 좋아요 개수가 많아질 경우 성능 저하가 발생할 수 있기 때문에, 향후 개선 논의가 필요할 것 같습니다.

## 🎸 기타
- 