### PR TITLE
fix: `MailSender` Bean 중복 등록과 `@DomainService`로 인한 스프링 컨텍스트 로드 실패 오류 수정

### DIFF
--- a/src/main/java/es/princip/getp/domain/auth/infra/EmailVerificationCodeSender.java
+++ b/src/main/java/es/princip/getp/domain/auth/infra/EmailVerificationCodeSender.java
@@ -3,7 +3,7 @@ package es.princip.getp.domain.auth.infra;
 import es.princip.getp.domain.auth.application.VerificationCodeSender;
 import es.princip.getp.domain.auth.exception.FailedVerificationCodeSendingException;
 import es.princip.getp.domain.member.command.domain.model.Email;
-import es.princip.getp.infra.mail.MailSender;
+import es.princip.getp.infra.mail.EmailSender;
 import es.princip.getp.infra.mail.command.SendMailCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class MailVerificationCodeSender implements VerificationCodeSender {
+public class EmailVerificationCodeSender implements VerificationCodeSender {
 
-    private final MailSender mailSender;
+    private final EmailSender emailSender;
 
     private static String title() {
         return "[GET-P] 회원가입 인증 코드";
@@ -38,7 +38,7 @@ public class MailVerificationCodeSender implements VerificationCodeSender {
             text(verificationCode)
         );
         try {
-            mailSender.send(command);
+            emailSender.send(command);
         } catch (MailException exception) {
             throw new FailedVerificationCodeSendingException();
         }

--- a/src/main/java/es/princip/getp/domain/common/annotation/DomainService.java
+++ b/src/main/java/es/princip/getp/domain/common/annotation/DomainService.java
@@ -1,8 +1,0 @@
-package es.princip.getp.domain.common.annotation;
-
-import org.springframework.stereotype.Component;
-
-@Component
-public @interface DomainService {
-    
-}

--- a/src/main/java/es/princip/getp/domain/people/command/domain/PeopleProfileChecker.java
+++ b/src/main/java/es/princip/getp/domain/people/command/domain/PeopleProfileChecker.java
@@ -1,10 +1,10 @@
 package es.princip.getp.domain.people.command.domain;
 
-import es.princip.getp.domain.common.annotation.DomainService;
 import es.princip.getp.domain.people.exception.NotRegisteredPeopleProfileException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
-@DomainService
+@Component
 @RequiredArgsConstructor
 public class PeopleProfileChecker {
 

--- a/src/main/java/es/princip/getp/domain/project/command/domain/ProjectApplier.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/ProjectApplier.java
@@ -1,19 +1,19 @@
 package es.princip.getp.domain.project.command.domain;
 
-import es.princip.getp.domain.common.annotation.DomainService;
 import es.princip.getp.domain.common.domain.ClockHolder;
 import es.princip.getp.domain.common.domain.Duration;
 import es.princip.getp.domain.people.command.domain.People;
 import es.princip.getp.domain.people.command.domain.PeopleProfileChecker;
 import es.princip.getp.domain.project.exception.ClosedProjectApplicationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.util.List;
 
 import static es.princip.getp.domain.project.command.domain.ProjectApplicationStatus.APPLICATION_COMPLETED;
 
-@DomainService
+@Component
 @RequiredArgsConstructor
 public class ProjectApplier {
 

--- a/src/main/java/es/princip/getp/domain/project/command/domain/ProjectCommissioner.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/ProjectCommissioner.java
@@ -1,15 +1,15 @@
 package es.princip.getp.domain.project.command.domain;
 
-import es.princip.getp.domain.common.annotation.DomainService;
 import es.princip.getp.domain.common.domain.ClockHolder;
 import es.princip.getp.domain.common.domain.Duration;
 import es.princip.getp.domain.project.exception.ApplicationDurationNotBeforeEstimatedDurationException;
 import es.princip.getp.domain.project.exception.EndedApplicationDurationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 
-@DomainService
+@Component
 @RequiredArgsConstructor
 public class ProjectCommissioner {
 

--- a/src/main/java/es/princip/getp/domain/project/command/domain/ProjectMeetingScheduler.java
+++ b/src/main/java/es/princip/getp/domain/project/command/domain/ProjectMeetingScheduler.java
@@ -1,6 +1,5 @@
 package es.princip.getp.domain.project.command.domain;
 
-import es.princip.getp.domain.common.annotation.DomainService;
 import es.princip.getp.domain.common.domain.MeetingSchedule;
 import es.princip.getp.domain.member.command.domain.model.PhoneNumber;
 import es.princip.getp.domain.people.command.domain.People;
@@ -8,8 +7,9 @@ import es.princip.getp.domain.people.command.domain.PeopleProfileChecker;
 import es.princip.getp.domain.project.exception.NotApplicantException;
 import es.princip.getp.domain.project.exception.NotClientOfProjectException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
-@DomainService
+@Component
 @RequiredArgsConstructor
 public class ProjectMeetingScheduler {
 

--- a/src/main/java/es/princip/getp/domain/project/command/infra/EmailMeetingSender.java
+++ b/src/main/java/es/princip/getp/domain/project/command/infra/EmailMeetingSender.java
@@ -5,7 +5,7 @@ import es.princip.getp.domain.project.command.application.MeetingSender;
 import es.princip.getp.domain.project.command.domain.Project;
 import es.princip.getp.domain.project.command.domain.ProjectMeeting;
 import es.princip.getp.domain.project.exception.FailedMeetingSendingException;
-import es.princip.getp.infra.mail.MailSender;
+import es.princip.getp.infra.mail.EmailSender;
 import es.princip.getp.infra.mail.command.SendMailCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
@@ -13,9 +13,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class MailMeetingSender implements MeetingSender {
+public class EmailMeetingSender implements MeetingSender {
 
-    private final MailSender mailSender;
+    private final EmailSender emailSender;
 
     private String title(final Project project) {
         return String.format("[GET-P] %s 미팅 신청", project.getTitle());
@@ -52,7 +52,7 @@ public class MailMeetingSender implements MeetingSender {
             text(project, meeting)
         );
         try {
-            mailSender.send(message);
+            emailSender.send(message);
         } catch (MailException exception) {
             throw new FailedMeetingSendingException();
         }

--- a/src/main/java/es/princip/getp/infra/mail/EmailSender.java
+++ b/src/main/java/es/princip/getp/infra/mail/EmailSender.java
@@ -3,17 +3,17 @@ package es.princip.getp.infra.mail;
 import es.princip.getp.infra.mail.command.SendMailCommand;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class MailSender {
+public class EmailSender {
 
-    private final JavaMailSender mailSender;
+    private final MailSender mailSender;
 
     @Async
     public void send(final SendMailCommand command) {


### PR DESCRIPTION
## ✨ 구현한 기능
- `MailSender` Bean 중복 등록과 `@DomainService`로 인한 스프링 컨텍스트 로드 실패 오류 수정

## 📢 논의하고 싶은 내용
- 이와 같은 일을 방지하고자 컨텍스트 로드에 대한 테스트를 만들어야 할 것 같습니다.

## 🎸 기타
- 