### PR TITLE
fix: 사진 삭제 시 URI로부터 잘못된 경로를 생성하는 오류 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     container_name: get-p-server
     env_file:
-      - .env.dev
+      - ${ENV_FILE}
     depends_on:
       - redis
       - database
@@ -13,7 +13,9 @@ services:
       - ${SPRING_PORT}:${SPRING_PORT}
     restart: always
     volumes:
-      - /data:/storage
+      - type: bind
+        source: ${SERVER_STORAGE_PATH}
+        target: ${STORAGE_PATH}
 
   database:
     image: mysql:9.0.0

--- a/src/main/java/es/princip/getp/infra/storage/infra/LocalImageStorage.java
+++ b/src/main/java/es/princip/getp/infra/storage/infra/LocalImageStorage.java
@@ -17,9 +17,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
-@Component
 @Slf4j
 @Getter
+@Component
 public class LocalImageStorage implements ImageStorage {
 
     public LocalImageStorage(
@@ -61,13 +61,13 @@ public class LocalImageStorage implements ImageStorage {
      */
     @Override
     public void deleteImage(URI destination) {
-        final Path path = Paths.get(contextPath).relativize(Paths.get(destination.getPath()));
+        Path path = Paths.get(destination.getPath().replaceFirst("/", ""));
+        if (!path.startsWith(getAbsoluteImageStoragePath())) {
+            path = storagePath.resolve(path);
+        }
+        log.debug("실제 삭제 경로: {}", path);
         try {
-            if (path.startsWith(getAbsoluteImageStoragePath())) {
-                Files.delete(path);
-            } else {
-                Files.delete(this.storagePath.resolve(path));
-            }
+            Files.delete(path);
         } catch (IOException exception) {
             throw new FailedImageSaveException();
         }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -66,6 +66,7 @@ spring:
 
 logging:
   level:
+    es.princip.getp: DEBUG
     org:
       springframework:
         security: DEBUG


### PR DESCRIPTION
## ✨ 구현한 기능
- 사진 삭제 시 URI로부터 잘못된 경로를 생성하는 오류 수정

## 📢 논의하고 싶은 내용
- 현재 사진 스토리지와 파일 스토리지가 유사한 로직을 가지고 있습니다. 이에 관해 리팩토링이 필요할 것 같습니다.

## 🎸 기타
- 