### PR TITLE
GETP-185 fix: 피플 프로필이 미등록 상태임에도 등록할 수 없는 오류 수정

### DIFF
--- a/src/main/java/es/princip/getp/domain/like/query/dao/PeopleLikeQueryDslDao.java
+++ b/src/main/java/es/princip/getp/domain/like/query/dao/PeopleLikeQueryDslDao.java
@@ -3,6 +3,7 @@ package es.princip.getp.domain.like.query.dao;
 import es.princip.getp.infra.support.QueryDslSupport;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -22,7 +23,9 @@ public class PeopleLikeQueryDslDao extends QueryDslSupport implements PeopleLike
 
     @Override
     public Map<Long, Long> countByLikedIds(Long... likedIds) {
-        return queryFactory.select(peopleLike.likedId, peopleLike.count())
+        final Map<Long, Long> counts = Arrays.stream(likedIds)
+            .collect(toMap(id -> id, id -> 0L));
+        final Map<Long, Long> result = queryFactory.select(peopleLike.likedId, peopleLike.count())
             .from(peopleLike)
             .where(peopleLike.likedId.in(likedIds))
             .groupBy(peopleLike.likedId)
@@ -35,5 +38,7 @@ public class PeopleLikeQueryDslDao extends QueryDslSupport implements PeopleLike
                         .orElse(0L)
                 )
             );
+        counts.putAll(result);
+        return counts;
     }
 }

--- a/src/main/java/es/princip/getp/domain/like/query/dao/ProjectLikeQueryDslDao.java
+++ b/src/main/java/es/princip/getp/domain/like/query/dao/ProjectLikeQueryDslDao.java
@@ -3,6 +3,7 @@ package es.princip.getp.domain.like.query.dao;
 import es.princip.getp.infra.support.QueryDslSupport;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -23,7 +24,9 @@ public class ProjectLikeQueryDslDao extends QueryDslSupport implements ProjectLi
 
     @Override
     public Map<Long, Long> countByLikedIds(final Long... likedIds) {
-        return queryFactory.select(projectLike.likedId, projectLike.count())
+        final Map<Long, Long> counts = Arrays.stream(likedIds)
+            .collect(toMap(id -> id, id -> 0L));
+        final Map<Long, Long> result = queryFactory.select(projectLike.likedId, projectLike.count())
             .from(projectLike)
             .where(projectLike.likedId.in(likedIds))
             .groupBy(projectLike.likedId)
@@ -36,5 +39,7 @@ public class ProjectLikeQueryDslDao extends QueryDslSupport implements ProjectLi
                         .orElse(0L)
                 )
             );
+        counts.putAll(result);
+        return counts;
     }
 }

--- a/src/main/java/es/princip/getp/domain/people/command/domain/People.java
+++ b/src/main/java/es/princip/getp/domain/people/command/domain/People.java
@@ -5,6 +5,7 @@ import es.princip.getp.domain.like.command.domain.LikeReceivable;
 import es.princip.getp.domain.like.command.domain.Likeable;
 import es.princip.getp.domain.member.command.domain.model.Email;
 import es.princip.getp.domain.people.exception.AlreadyRegisteredPeopleProfileException;
+import es.princip.getp.domain.people.exception.NotRegisteredPeopleProfileException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -60,10 +61,13 @@ public class People extends BaseTimeEntity implements Likeable, LikeReceivable {
     }
 
     public boolean isProfileRegistered() {
-        return this.profile != null;
+        return this.profile != null && this.profile.isRegistered();
     }
 
     public void editProfile(final PeopleProfileData data) {
+        if (!isProfileRegistered()) {
+            throw new NotRegisteredPeopleProfileException();
+        }
         this.profile = buildProfile(data);
     }
 

--- a/src/main/java/es/princip/getp/domain/people/command/domain/PeopleProfile.java
+++ b/src/main/java/es/princip/getp/domain/people/command/domain/PeopleProfile.java
@@ -71,4 +71,8 @@ public class PeopleProfile {
     public List<Portfolio> getPortfolios() {
         return Collections.unmodifiableList(portfolios);
     }
+
+    public boolean isRegistered() {
+        return this.introduction != null || this.activityArea != null || this.education != null;
+    }
 }

--- a/src/main/java/es/princip/getp/domain/people/exception/NotRegisteredPeopleProfileException.java
+++ b/src/main/java/es/princip/getp/domain/people/exception/NotRegisteredPeopleProfileException.java
@@ -6,7 +6,7 @@ import es.princip.getp.infra.exception.ErrorDescription;
 public class NotRegisteredPeopleProfileException extends BusinessLogicException {
 
     private static final String code = "NOT_REGISTERED_PEOPLE_PROFILE";
-    private static final String message = "프로젝트에 지원하려면 피플 프로필을 등록해야 합니다.";
+    private static final String message = "프로필을 먼저 등록해주세요.";
 
     public NotRegisteredPeopleProfileException() {
         super(ErrorDescription.of(code, message));

--- a/src/test/java/es/princip/getp/domain/like/query/dao/ZeroTestSizePeopleLikeDaoTest.java
+++ b/src/test/java/es/princip/getp/domain/like/query/dao/ZeroTestSizePeopleLikeDaoTest.java
@@ -14,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @Import(PeopleLikeDaoConfig.class)
-public class PeopleLikeDaoTest extends DaoTest {
+public class ZeroTestSizePeopleLikeDaoTest extends DaoTest {
 
-    public PeopleLikeDaoTest() {
-        super(10);
+    public ZeroTestSizePeopleLikeDaoTest() {
+        super(0);
     }
 
     @Autowired
@@ -25,17 +25,17 @@ public class PeopleLikeDaoTest extends DaoTest {
 
     @Test
     void 피플_ID에_대해_피플이_받은_좋아요_수를_조회한다() {
-        assertThat(peopleLikeDao.countByLikedId(1L)).isEqualTo(TEST_SIZE);
+        assertThat(peopleLikeDao.countByLikedId(1L)).isEqualTo(0);
     }
 
     @Test
     void 여러개의_피플_ID에_대해_피플이_받은_좋아요_수를_조회한다() {
-        final Long[] peopleIds = LongStream.rangeClosed(1, TEST_SIZE)
+        final Long[] peopleIds = LongStream.rangeClosed(1, 10)
             .boxed()
             .toArray(Long[]::new);
         final Map<Long, Long> likesCounts = peopleLikeDao.countByLikedIds(peopleIds);
         assertThat(likesCounts).hasSize(peopleIds.length)
             .containsOnlyKeys(peopleIds)
-            .containsValues(Long.valueOf(TEST_SIZE));
+            .containsValues(Long.valueOf(0));
     }
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- 피플 프로필이 미등록 상태임에도 등록할 수 없는 오류 수정

## 📢 논의하고 싶은 내용
- JPA의 `@Embeddable`에서, JPA의 구현체로 Hibernate를 사용하는 경우 `@Embeddable` 객체의 모든 필드가 `null`인 경우 Hibernate는 해당 객체 자체를 `null`로 설정합니다. 이를 이용해 `@Embeddable`인 `PeopleProfile`이 `null`인 경우 프로필을 등록하지 않은 것으로 판단했습니다. 그러나 `PeopleProfile` 객체의 `hastags`, `techStacks`, `portfolios`의 기본값이 `null`이 아니라 빈 `ArrayList`이기 때문에 모든 필드가 `null`이 아님으로 프로필을 등록하지 않아도 `PeopleProfile`이 `null`이 아니게 되어 버그가 발생했었습니다. 이를 이번 PR과 같이 수정하였습니다.

## 🎸 기타
- 