### PR TITLE
GETP-196 fix: `MemberJpaEntity`의 builder에서 초기화 표현식을 무시하지 않도록 `@Builder.Default` 추가

### DIFF
--- a/src/main/java/es/princip/getp/persistence/adapter/member/MemberJpaEntity.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/member/MemberJpaEntity.java
@@ -45,6 +45,7 @@ public class MemberJpaEntity extends BaseTimeEntity {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
+    @Builder.Default
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
         name = "member_service_term_agreement",


### PR DESCRIPTION
## ✨ 구현한 기능
- `MemberJpaEntity`의 builder에서 초기화 표현식을 무시하지 않도록 `@Builder.Default` 추가

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 