### PR TITLE
GETP-224 fix: people_like 테이블과 project_like 테이블의 primary key 이름을 JPA 매핑에 맞게 변경

### DIFF
--- a/src/main/java/es/princip/getp/domain/like/people/model/PeopleLike.java
+++ b/src/main/java/es/princip/getp/domain/like/people/model/PeopleLike.java
@@ -19,10 +19,9 @@ public class PeopleLike extends BaseEntity {
         final Long id,
         final Long clientId,
         final Long peopleId,
-        final LocalDateTime createdAt,
-        final LocalDateTime updatedAt
+        final LocalDateTime createdAt
     ) {
-        super(createdAt, updatedAt);
+        super(createdAt, null);
 
         this.id = id;
         this.clientId = clientId;

--- a/src/main/java/es/princip/getp/domain/like/project/model/ProjectLike.java
+++ b/src/main/java/es/princip/getp/domain/like/project/model/ProjectLike.java
@@ -19,10 +19,9 @@ public class ProjectLike extends BaseEntity {
         final Long id,
         final Long peopleId,
         final Long projectId,
-        final LocalDateTime createdAt,
-        final LocalDateTime updatedAt
+        final LocalDateTime createdAt
     ) {
-        super(createdAt, updatedAt);
+        super(createdAt, null);
 
         this.id = id;
         this.peopleId = peopleId;

--- a/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikeJpaEntity.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikeJpaEntity.java
@@ -1,21 +1,24 @@
 package es.princip.getp.persistence.adapter.like.people;
 
-import es.princip.getp.persistence.adapter.BaseTimeJpaEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
 @Table(name = "people_like")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PeopleLikeJpaEntity extends BaseTimeJpaEntity {
+public class PeopleLikeJpaEntity {
 
     @Id
+    @Column(name = "people_like_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -25,18 +28,20 @@ public class PeopleLikeJpaEntity extends BaseTimeJpaEntity {
     @Column(name = "people_id")
     private Long peopleId;
 
+    @CreatedDate
+    @Column(columnDefinition = "TIMESTAMP")
+    protected LocalDateTime createdAt;
+
     @Builder
     public PeopleLikeJpaEntity(
         final Long id,
         final Long clientId,
         final Long peopleId,
-        final LocalDateTime createdAt,
-        final LocalDateTime updatedAt
+        final LocalDateTime createdAt
     ) {
-        super(createdAt, updatedAt);
-
         this.id = id;
         this.clientId = clientId;
         this.peopleId = peopleId;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikeJpaEntity.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikeJpaEntity.java
@@ -1,21 +1,24 @@
 package es.princip.getp.persistence.adapter.like.project;
 
-import es.princip.getp.persistence.adapter.BaseTimeJpaEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
 @Table(name = "project_like")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProjectLikeJpaEntity extends BaseTimeJpaEntity {
+public class ProjectLikeJpaEntity {
 
     @Id
+    @Column(name = "project_like_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -25,18 +28,20 @@ public class ProjectLikeJpaEntity extends BaseTimeJpaEntity {
     @Column(name = "project_id")
     private Long projectId;
 
+    @CreatedDate
+    @Column(columnDefinition = "TIMESTAMP")
+    protected LocalDateTime createdAt;
+
     @Builder
     public ProjectLikeJpaEntity(
         final Long id,
         final Long peopleId,
         final Long projectId,
-        final LocalDateTime createdAt,
-        final LocalDateTime updatedAt
+        final LocalDateTime createdAt
     ) {
-        super(createdAt, updatedAt);
-
         this.id = id;
         this.peopleId = peopleId;
         this.projectId = projectId;
+        this.createdAt = createdAt;
     }
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- people_like 테이블과 project_like 테이블의 primary key 이름을 JPA 매핑에 맞게 변경

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 