### PR TITLE
GETP-232 feat: 피플 상세 조회 DTO에 좋아요 여부 필드 추가

### DIFF
--- a/src/docs/asciidoc/people/get-people.adoc
+++ b/src/docs/asciidoc/people/get-people.adoc
@@ -14,4 +14,4 @@ include::{snippets}/get-people/get-people_-when-user-logined/http-response.adoc[
 include::{snippets}/get-people/get-people_-when-user-not-logined/http-response.adoc[]
 
 ==== Response fields
-include::{snippets}/get-people/get-people_-when-user-not-logined/response-fields-data.adoc[]
+include::{snippets}/get-people/get-people_-when-user-logined/response-fields-data.adoc[]

--- a/src/main/java/es/princip/getp/api/controller/people/query/PeopleQueryController.java
+++ b/src/main/java/es/princip/getp/api/controller/people/query/PeopleQueryController.java
@@ -1,13 +1,15 @@
 package es.princip.getp.api.controller.people.query;
 
+import es.princip.getp.api.controller.people.query.dto.people.CardPeopleResponse;
+import es.princip.getp.api.controller.people.query.dto.people.DetailPeopleResponse;
+import es.princip.getp.api.controller.people.query.dto.people.PublicDetailPeopleResponse;
+import es.princip.getp.api.security.details.PrincipalDetails;
 import es.princip.getp.api.support.ControllerSupport;
 import es.princip.getp.api.support.dto.ApiResponse;
 import es.princip.getp.api.support.dto.ApiResponse.ApiSuccessResult;
 import es.princip.getp.api.support.dto.PageResponse;
-import es.princip.getp.api.controller.people.query.dto.people.CardPeopleResponse;
-import es.princip.getp.api.controller.people.query.dto.people.DetailPeopleResponse;
-import es.princip.getp.api.controller.people.query.dto.people.PublicDetailPeopleResponse;
 import es.princip.getp.application.people.port.in.GetPeopleQuery;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,10 +37,14 @@ public class PeopleQueryController extends ControllerSupport {
      * @return 피플 ID에 해당되는 피플 상세 정보
      */
     @GetMapping("/{peopleId}")
-    public ResponseEntity<? extends ApiSuccessResult<?>> getPeople(@PathVariable final Long peopleId) {
+    public ResponseEntity<? extends ApiSuccessResult<?>> getPeople(
+        @AuthenticationPrincipal final PrincipalDetails principalDetails,
+        @PathVariable final Long peopleId
+    ) {
         final PeopleId id = new PeopleId(peopleId);
-        if (isAuthenticated()) {
-            final DetailPeopleResponse response = getPeopleQuery.getDetailBy(id);
+        if (isAuthenticated(principalDetails)) {
+            final MemberId memberId = principalDetails.getMember().getId();
+            final DetailPeopleResponse response = getPeopleQuery.getDetailBy(memberId, id);
             return ApiResponse.success(HttpStatus.OK, response);
         }
         final PublicDetailPeopleResponse response = getPeopleQuery.getPublicDetailBy(id);

--- a/src/main/java/es/princip/getp/api/controller/people/query/dto/people/DetailPeopleResponse.java
+++ b/src/main/java/es/princip/getp/api/controller/people/query/dto/people/DetailPeopleResponse.java
@@ -1,8 +1,10 @@
 package es.princip.getp.api.controller.people.query.dto.people;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import es.princip.getp.api.controller.people.query.dto.peopleProfile.DetailPeopleProfileResponse;
 import es.princip.getp.domain.people.model.PeopleType;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record DetailPeopleResponse(
     Long peopleId,
     String nickname,
@@ -10,6 +12,7 @@ public record DetailPeopleResponse(
     PeopleType peopleType,
     long completedProjectsCount,
     long likesCount,
+    Boolean liked,
     DetailPeopleProfileResponse profile
 ) {
 }

--- a/src/main/java/es/princip/getp/api/support/ControllerSupport.java
+++ b/src/main/java/es/princip/getp/api/support/ControllerSupport.java
@@ -1,5 +1,6 @@
 package es.princip.getp.api.support;
 
+import es.princip.getp.api.security.details.PrincipalDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -8,5 +9,9 @@ public abstract class ControllerSupport {
     public boolean isAuthenticated() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return authentication != null && authentication.isAuthenticated();
+    }
+
+    public boolean isAuthenticated(final PrincipalDetails principalDetails) {
+        return isAuthenticated() && principalDetails != null;
     }
 }

--- a/src/main/java/es/princip/getp/application/like/people/port/out/CheckPeopleLikePort.java
+++ b/src/main/java/es/princip/getp/application/like/people/port/out/CheckPeopleLikePort.java
@@ -1,9 +1,9 @@
 package es.princip.getp.application.like.people.port.out;
 
-import es.princip.getp.domain.client.model.ClientId;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
 
 public interface CheckPeopleLikePort {
 
-    boolean existsBy(ClientId clientId, PeopleId peopleId);
+    boolean existsBy(MemberId memberId, PeopleId peopleId);
 }

--- a/src/main/java/es/princip/getp/application/like/people/port/out/LoadPeopleLikePort.java
+++ b/src/main/java/es/princip/getp/application/like/people/port/out/LoadPeopleLikePort.java
@@ -1,10 +1,10 @@
 package es.princip.getp.application.like.people.port.out;
 
-import es.princip.getp.domain.client.model.ClientId;
 import es.princip.getp.domain.like.people.model.PeopleLike;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
 
 public interface LoadPeopleLikePort {
 
-    PeopleLike loadBy(ClientId clientId, PeopleId peopleId);
+    PeopleLike loadBy(MemberId memberId, PeopleId peopleId);
 }

--- a/src/main/java/es/princip/getp/application/like/people/service/LikePeopleService.java
+++ b/src/main/java/es/princip/getp/application/like/people/service/LikePeopleService.java
@@ -1,13 +1,10 @@
 package es.princip.getp.application.like.people.service;
 
-import es.princip.getp.application.client.port.out.LoadClientPort;
 import es.princip.getp.application.like.exception.AlreadyLikedException;
 import es.princip.getp.application.like.people.port.in.LikePeopleUseCase;
 import es.princip.getp.application.like.people.port.out.CheckPeopleLikePort;
 import es.princip.getp.application.like.people.port.out.SavePeopleLikePort;
 import es.princip.getp.application.people.port.out.LoadPeoplePort;
-import es.princip.getp.domain.client.model.Client;
-import es.princip.getp.domain.client.model.ClientId;
 import es.princip.getp.domain.like.people.model.PeopleLike;
 import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.People;
@@ -21,30 +18,28 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 class LikePeopleService implements LikePeopleUseCase {
 
-    private final LoadClientPort loadClientPort;
     private final LoadPeoplePort loadPeoplePort;
     private final CheckPeopleLikePort checkPeopleLikePort;
     private final SavePeopleLikePort savePeopleLikePort;
 
     @Transactional
     public void like(final MemberId memberId, final PeopleId peopleId) {
-        final Client client = loadClientPort.loadBy(memberId);
         // TODO: 조회 성능 개선 필요
         final People people = loadPeoplePort.loadBy(peopleId);
-        checkAlreadyLiked(client.getId(), peopleId);
-        final PeopleLike peopleLike = buildPeopleLike(client.getId(), peopleId);
+        checkAlreadyLiked(memberId, peopleId);
+        final PeopleLike peopleLike = buildPeopleLike(memberId, peopleId);
         savePeopleLikePort.save(peopleLike);
     }
 
-    private void checkAlreadyLiked(final ClientId clientId, final PeopleId peopleId) {
-        if (checkPeopleLikePort.existsBy(clientId, peopleId)) {
+    private void checkAlreadyLiked(final MemberId memberId, final PeopleId peopleId) {
+        if (checkPeopleLikePort.existsBy(memberId, peopleId)) {
             throw new AlreadyLikedException();
         }
     }
 
-    private PeopleLike buildPeopleLike(final ClientId clientId, final PeopleId peopleId) {
+    private PeopleLike buildPeopleLike(final MemberId memberId, final PeopleId peopleId) {
         return PeopleLike.builder()
-            .clientId(clientId)
+            .memberId(memberId)
             .peopleId(peopleId)
             .build();
     }

--- a/src/main/java/es/princip/getp/application/like/people/service/UnlikePeopleService.java
+++ b/src/main/java/es/princip/getp/application/like/people/service/UnlikePeopleService.java
@@ -1,14 +1,11 @@
 package es.princip.getp.application.like.people.service;
 
-import es.princip.getp.application.client.port.out.LoadClientPort;
 import es.princip.getp.application.like.exception.NeverLikedException;
 import es.princip.getp.application.like.people.port.in.UnlikePeopleUseCase;
 import es.princip.getp.application.like.people.port.out.CheckPeopleLikePort;
 import es.princip.getp.application.like.people.port.out.DeletePeopleLikePort;
 import es.princip.getp.application.like.people.port.out.LoadPeopleLikePort;
 import es.princip.getp.application.people.port.out.LoadPeoplePort;
-import es.princip.getp.domain.client.model.Client;
-import es.princip.getp.domain.client.model.ClientId;
 import es.princip.getp.domain.like.people.model.PeopleLike;
 import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.People;
@@ -22,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 class UnlikePeopleService implements UnlikePeopleUseCase {
 
-    private final LoadClientPort loadClientPort;
     private final LoadPeoplePort loadPeoplePort;
     private final LoadPeopleLikePort loadPeopleLikePort;
     private final CheckPeopleLikePort checkPeopleLikePort;
@@ -30,16 +26,15 @@ class UnlikePeopleService implements UnlikePeopleUseCase {
 
     @Transactional
     public void unlike(final MemberId memberId, final PeopleId peopleId) {
-        final Client client = loadClientPort.loadBy(memberId);
         // TODO: 조회 성능 개선 필요
         final People people = loadPeoplePort.loadBy(peopleId);
-        final PeopleLike peopleLike = loadPeopleLikePort.loadBy(client.getId(), peopleId);
-        checkNeverLiked(client.getId(), peopleId);
+        final PeopleLike peopleLike = loadPeopleLikePort.loadBy(memberId, peopleId);
+        checkNeverLiked(memberId, peopleId);
         deletePeopleLikePort.delete(peopleLike);
     }
 
-    private void checkNeverLiked(final ClientId clientId, final PeopleId peopleId) {
-        if (!checkPeopleLikePort.existsBy(clientId, peopleId)) {
+    private void checkNeverLiked(final MemberId memberId, final PeopleId peopleId) {
+        if (!checkPeopleLikePort.existsBy(memberId, peopleId)) {
             throw new NeverLikedException();
         } 
     }

--- a/src/main/java/es/princip/getp/application/like/project/port/out/CheckProjectLikePort.java
+++ b/src/main/java/es/princip/getp/application/like/project/port/out/CheckProjectLikePort.java
@@ -1,9 +1,9 @@
 package es.princip.getp.application.like.project.port.out;
 
-import es.princip.getp.domain.people.model.PeopleId;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.project.commission.model.ProjectId;
 
 public interface CheckProjectLikePort {
 
-    boolean existsBy(PeopleId peopleId, ProjectId projectId);
+    boolean existsBy(MemberId memberId, ProjectId projectId);
 }

--- a/src/main/java/es/princip/getp/application/like/project/port/out/LoadProjectLikePort.java
+++ b/src/main/java/es/princip/getp/application/like/project/port/out/LoadProjectLikePort.java
@@ -1,10 +1,10 @@
 package es.princip.getp.application.like.project.port.out;
 
 import es.princip.getp.domain.like.project.model.ProjectLike;
-import es.princip.getp.domain.people.model.PeopleId;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.project.commission.model.ProjectId;
 
 public interface LoadProjectLikePort {
 
-    ProjectLike loadBy(PeopleId peopleId, ProjectId projectId);
+    ProjectLike loadBy(MemberId memberId, ProjectId projectId);
 }

--- a/src/main/java/es/princip/getp/application/like/project/service/LikeProjectService.java
+++ b/src/main/java/es/princip/getp/application/like/project/service/LikeProjectService.java
@@ -4,12 +4,9 @@ import es.princip.getp.application.like.exception.AlreadyLikedException;
 import es.princip.getp.application.like.project.port.in.LikeProjectUseCase;
 import es.princip.getp.application.like.project.port.out.CheckProjectLikePort;
 import es.princip.getp.application.like.project.port.out.SaveProjectLikePort;
-import es.princip.getp.application.people.port.out.LoadPeoplePort;
 import es.princip.getp.application.project.commission.port.out.LoadProjectPort;
 import es.princip.getp.domain.like.project.model.ProjectLike;
 import es.princip.getp.domain.member.model.MemberId;
-import es.princip.getp.domain.people.model.People;
-import es.princip.getp.domain.people.model.PeopleId;
 import es.princip.getp.domain.project.commission.model.Project;
 import es.princip.getp.domain.project.commission.model.ProjectId;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 class LikeProjectService implements LikeProjectUseCase {
 
     private final LoadProjectPort loadProjectPort;
-    private final LoadPeoplePort loadPeoplePort;
     private final CheckProjectLikePort checkProjectLikePort;
     private final SaveProjectLikePort saveProjectLikePort;
 
@@ -34,23 +30,22 @@ class LikeProjectService implements LikeProjectUseCase {
      */
     @Transactional
     public void like(final MemberId memberId, final ProjectId projectId) {
-        final People people = loadPeoplePort.loadBy(memberId);
         // TODO: 조회 성능 개선 필요
         final Project project = loadProjectPort.loadBy(projectId);
-        checkAlreadyLiked(people.getId(), projectId);
-        final ProjectLike projectLike = buildProjectLike(people.getId(), projectId);
+        checkAlreadyLiked(memberId, projectId);
+        final ProjectLike projectLike = buildProjectLike(memberId, projectId);
         saveProjectLikePort.save(projectLike);
     }
 
-    private void checkAlreadyLiked(final PeopleId peopleId, final ProjectId projectId) {
-        if (checkProjectLikePort.existsBy(peopleId, projectId)) {
+    private void checkAlreadyLiked(final MemberId memberId, final ProjectId projectId) {
+        if (checkProjectLikePort.existsBy(memberId, projectId)) {
             throw new AlreadyLikedException();
         }
     }
 
-    private ProjectLike buildProjectLike(final PeopleId peopleId, final ProjectId projectId) {
+    private ProjectLike buildProjectLike(final MemberId memberId, final ProjectId projectId) {
         return ProjectLike.builder()
-            .peopleId(peopleId)
+            .memberId(memberId)
             .projectId(projectId)
             .build();
     }

--- a/src/main/java/es/princip/getp/application/like/project/service/UnlikeProjectService.java
+++ b/src/main/java/es/princip/getp/application/like/project/service/UnlikeProjectService.java
@@ -5,12 +5,9 @@ import es.princip.getp.application.like.project.port.in.UnlikeProjectUseCase;
 import es.princip.getp.application.like.project.port.out.CheckProjectLikePort;
 import es.princip.getp.application.like.project.port.out.DeleteProjectLikePort;
 import es.princip.getp.application.like.project.port.out.LoadProjectLikePort;
-import es.princip.getp.application.people.port.out.LoadPeoplePort;
 import es.princip.getp.application.project.commission.port.out.LoadProjectPort;
 import es.princip.getp.domain.like.project.model.ProjectLike;
 import es.princip.getp.domain.member.model.MemberId;
-import es.princip.getp.domain.people.model.People;
-import es.princip.getp.domain.people.model.PeopleId;
 import es.princip.getp.domain.project.commission.model.Project;
 import es.princip.getp.domain.project.commission.model.ProjectId;
 import lombok.RequiredArgsConstructor;
@@ -23,23 +20,21 @@ import org.springframework.transaction.annotation.Transactional;
 class UnlikeProjectService implements UnlikeProjectUseCase {
 
     private final LoadProjectLikePort loadProjectLikePort;
-    private final LoadPeoplePort loadPeoplePort;
     private final LoadProjectPort loadProjectPort;
     private final CheckProjectLikePort checkProjectLikePort;
     private final DeleteProjectLikePort deleteProjectLikePort;
 
     @Transactional
     public void unlike(final MemberId memberId, final ProjectId projectId) {
-        final People people = loadPeoplePort.loadBy(memberId);
         // TODO: 조회 성능 개선 필요
         final Project project = loadProjectPort.loadBy(projectId);
-        checkNeverLiked(people.getId(), projectId);
-        final ProjectLike projectLike = loadProjectLikePort.loadBy(people.getId(), projectId);
+        checkNeverLiked(memberId, projectId);
+        final ProjectLike projectLike = loadProjectLikePort.loadBy(memberId, projectId);
         deleteProjectLikePort.delete(projectLike);
     }
 
-    private void checkNeverLiked(final PeopleId peopleId, final ProjectId projectId) {
-        if (!checkProjectLikePort.existsBy(peopleId, projectId)) {
+    private void checkNeverLiked(final MemberId memberId, final ProjectId projectId) {
+        if (!checkProjectLikePort.existsBy(memberId, projectId)) {
             throw new NeverLikedException();
         }
     }

--- a/src/main/java/es/princip/getp/application/people/port/in/GetPeopleQuery.java
+++ b/src/main/java/es/princip/getp/application/people/port/in/GetPeopleQuery.java
@@ -3,6 +3,7 @@ package es.princip.getp.application.people.port.in;
 import es.princip.getp.api.controller.people.query.dto.people.CardPeopleResponse;
 import es.princip.getp.api.controller.people.query.dto.people.DetailPeopleResponse;
 import es.princip.getp.api.controller.people.query.dto.people.PublicDetailPeopleResponse;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,7 +12,7 @@ public interface GetPeopleQuery {
 
     Page<CardPeopleResponse> getPagedCards(Pageable pageable);
 
-    DetailPeopleResponse getDetailBy(PeopleId peopleId);
+    DetailPeopleResponse getDetailBy(MemberId memberId, PeopleId peopleId);
 
     PublicDetailPeopleResponse getPublicDetailBy(PeopleId peopleId);
 }

--- a/src/main/java/es/princip/getp/application/people/port/out/FindPeoplePort.java
+++ b/src/main/java/es/princip/getp/application/people/port/out/FindPeoplePort.java
@@ -3,6 +3,7 @@ package es.princip.getp.application.people.port.out;
 import es.princip.getp.api.controller.people.query.dto.people.CardPeopleResponse;
 import es.princip.getp.api.controller.people.query.dto.people.DetailPeopleResponse;
 import es.princip.getp.api.controller.people.query.dto.people.PublicDetailPeopleResponse;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,7 +12,7 @@ public interface FindPeoplePort {
 
     Page<CardPeopleResponse> findCardBy(Pageable pageable);
 
-    DetailPeopleResponse findDetailBy(PeopleId peopleId);
+    DetailPeopleResponse findDetailBy(MemberId memberId, PeopleId peopleId);
 
     PublicDetailPeopleResponse findPublicDetailBy(PeopleId peopleId);
 }

--- a/src/main/java/es/princip/getp/application/people/service/GetPeopleService.java
+++ b/src/main/java/es/princip/getp/application/people/service/GetPeopleService.java
@@ -5,6 +5,7 @@ import es.princip.getp.api.controller.people.query.dto.people.DetailPeopleRespon
 import es.princip.getp.api.controller.people.query.dto.people.PublicDetailPeopleResponse;
 import es.princip.getp.application.people.port.in.GetPeopleQuery;
 import es.princip.getp.application.people.port.out.FindPeoplePort;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,8 +26,8 @@ public class GetPeopleService implements GetPeopleQuery {
     }
 
     @Override
-    public DetailPeopleResponse getDetailBy(final PeopleId peopleId) {
-        return findPeoplePort.findDetailBy(peopleId);
+    public DetailPeopleResponse getDetailBy(final MemberId memberId, final PeopleId peopleId) {
+        return findPeoplePort.findDetailBy(memberId, peopleId);
     }
 
     @Override

--- a/src/main/java/es/princip/getp/domain/like/people/model/PeopleLike.java
+++ b/src/main/java/es/princip/getp/domain/like/people/model/PeopleLike.java
@@ -1,6 +1,6 @@
 package es.princip.getp.domain.like.people.model;
 
-import es.princip.getp.domain.client.model.ClientId;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
 import es.princip.getp.domain.support.BaseEntity;
 import jakarta.validation.constraints.NotNull;
@@ -13,20 +13,20 @@ import java.time.LocalDateTime;
 public class PeopleLike extends BaseEntity {
 
     private final Long id;
-    @NotNull private final ClientId clientId;
+    @NotNull private final MemberId memberId;
     @NotNull private final PeopleId peopleId;
 
     @Builder
     public PeopleLike(
         final Long id,
-        final ClientId clientId,
+        final MemberId memberId,
         final PeopleId peopleId,
         final LocalDateTime createdAt
     ) {
         super(createdAt, null);
 
         this.id = id;
-        this.clientId = clientId;
+        this.memberId = memberId;
         this.peopleId = peopleId;
 
         validate();

--- a/src/main/java/es/princip/getp/domain/like/project/model/ProjectLike.java
+++ b/src/main/java/es/princip/getp/domain/like/project/model/ProjectLike.java
@@ -1,6 +1,6 @@
 package es.princip.getp.domain.like.project.model;
 
-import es.princip.getp.domain.people.model.PeopleId;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.project.commission.model.ProjectId;
 import es.princip.getp.domain.support.BaseEntity;
 import jakarta.validation.constraints.NotNull;
@@ -13,20 +13,20 @@ import java.time.LocalDateTime;
 public class ProjectLike extends BaseEntity {
 
     private final Long id;
-    @NotNull private final PeopleId peopleId;
+    @NotNull private final MemberId memberId;
     @NotNull private final ProjectId projectId;
 
     @Builder
     public ProjectLike(
         final Long id,
-        final PeopleId peopleId,
+        final MemberId memberId,
         final ProjectId projectId,
         final LocalDateTime createdAt
     ) {
         super(createdAt, null);
 
         this.id = id;
-        this.peopleId = peopleId;
+        this.memberId = memberId;
         this.projectId = projectId;
 
         validate();

--- a/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikeJpaEntity.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikeJpaEntity.java
@@ -22,8 +22,8 @@ public class PeopleLikeJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "client_id")
-    private Long clientId;
+    @Column(name = "member_id")
+    private Long memberId;
 
     @Column(name = "people_id")
     private Long peopleId;
@@ -35,12 +35,12 @@ public class PeopleLikeJpaEntity {
     @Builder
     public PeopleLikeJpaEntity(
         final Long id,
-        final Long clientId,
+        final Long memberId,
         final Long peopleId,
         final LocalDateTime createdAt
     ) {
         this.id = id;
-        this.clientId = clientId;
+        this.memberId = memberId;
         this.peopleId = peopleId;
         this.createdAt = createdAt;
     }

--- a/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikeJpaRepository.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikeJpaRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 public interface PeopleLikeJpaRepository extends JpaRepository<PeopleLikeJpaEntity, Long> {
 
-    boolean existsByClientIdAndPeopleId(Long clientId, Long peopleId);
+    boolean existsByMemberIdAndPeopleId(Long memberId, Long peopleId);
 
-    Optional<PeopleLikeJpaEntity> findByClientIdAndPeopleId(Long clientId, Long peopleId);
+    Optional<PeopleLikeJpaEntity> findByMemberIdAndPeopleId(Long memberId, Long peopleId);
 }

--- a/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikePersistenceAdapter.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikePersistenceAdapter.java
@@ -4,8 +4,8 @@ import es.princip.getp.application.like.people.port.out.CheckPeopleLikePort;
 import es.princip.getp.application.like.people.port.out.DeletePeopleLikePort;
 import es.princip.getp.application.like.people.port.out.LoadPeopleLikePort;
 import es.princip.getp.application.like.people.port.out.SavePeopleLikePort;
-import es.princip.getp.domain.client.model.ClientId;
 import es.princip.getp.domain.like.people.model.PeopleLike;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
 import es.princip.getp.persistence.adapter.like.exception.NotFoundLikeException;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +29,9 @@ class PeopleLikePersistenceAdapter implements
     }
 
     @Override
-    public boolean existsBy(final ClientId clientId, final PeopleId peopleId) {
-        return repository.existsByClientIdAndPeopleId(
-            clientId.getValue(),
+    public boolean existsBy(final MemberId memberId, final PeopleId peopleId) {
+        return repository.existsByMemberIdAndPeopleId(
+            memberId.getValue(),
             peopleId.getValue()
         );
     }
@@ -43,9 +43,9 @@ class PeopleLikePersistenceAdapter implements
     }
 
     @Override
-    public PeopleLike loadBy(final ClientId clientId, final PeopleId peopleId) {
-        final PeopleLikeJpaEntity entity = repository.findByClientIdAndPeopleId(
-                clientId.getValue(),
+    public PeopleLike loadBy(final MemberId memberId, final PeopleId peopleId) {
+        final PeopleLikeJpaEntity entity = repository.findByMemberIdAndPeopleId(
+                memberId.getValue(),
                 peopleId.getValue()
             )
             .orElseThrow(NotFoundLikeException::new);

--- a/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikePersistenceMapper.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/people/PeopleLikePersistenceMapper.java
@@ -8,7 +8,7 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface PeopleLikePersistenceMapper {
 
-    @Mapping(source = "clientId", target = "clientId.value")
+    @Mapping(source = "memberId", target = "memberId.value")
     @Mapping(source = "peopleId", target = "peopleId.value")
     PeopleLike mapToDomain(PeopleLikeJpaEntity peopleLikeJpaEntity);
 

--- a/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikeJpaEntity.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikeJpaEntity.java
@@ -22,8 +22,8 @@ public class ProjectLikeJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "people_id")
-    private Long peopleId;
+    @Column(name = "member_id")
+    private Long memberId;
 
     @Column(name = "project_id")
     private Long projectId;
@@ -35,12 +35,12 @@ public class ProjectLikeJpaEntity {
     @Builder
     public ProjectLikeJpaEntity(
         final Long id,
-        final Long peopleId,
+        final Long memberId,
         final Long projectId,
         final LocalDateTime createdAt
     ) {
         this.id = id;
-        this.peopleId = peopleId;
+        this.memberId = memberId;
         this.projectId = projectId;
         this.createdAt = createdAt;
     }

--- a/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikeJpaRepository.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikeJpaRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 public interface ProjectLikeJpaRepository extends JpaRepository<ProjectLikeJpaEntity, Long> {
 
-    boolean existsByPeopleIdAndProjectId(Long peopleId, Long projectId);
+    boolean existsByMemberIdAndProjectId(Long memberId, Long projectId);
 
-    Optional<ProjectLikeJpaEntity> findByPeopleIdAndProjectId(Long peopleId, Long projectId);
+    Optional<ProjectLikeJpaEntity> findByMemberIdAndProjectId(Long memberId, Long projectId);
 }

--- a/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikePersistenceAdapter.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikePersistenceAdapter.java
@@ -5,7 +5,7 @@ import es.princip.getp.application.like.project.port.out.DeleteProjectLikePort;
 import es.princip.getp.application.like.project.port.out.LoadProjectLikePort;
 import es.princip.getp.application.like.project.port.out.SaveProjectLikePort;
 import es.princip.getp.domain.like.project.model.ProjectLike;
-import es.princip.getp.domain.people.model.PeopleId;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.project.commission.model.ProjectId;
 import es.princip.getp.persistence.adapter.like.exception.NotFoundLikeException;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +29,9 @@ class ProjectLikePersistenceAdapter implements
     }
 
     @Override
-    public boolean existsBy(final PeopleId peopleId, ProjectId projectId) {
-        return repository.existsByPeopleIdAndProjectId(
-            peopleId.getValue(),
+    public boolean existsBy(final MemberId memberId, ProjectId projectId) {
+        return repository.existsByMemberIdAndProjectId(
+            memberId.getValue(),
             projectId.getValue()
         );
     }
@@ -43,9 +43,9 @@ class ProjectLikePersistenceAdapter implements
     }
 
     @Override
-    public ProjectLike loadBy(final PeopleId peopleId, final ProjectId projectId) {
-        final ProjectLikeJpaEntity jpaEntity = repository.findByPeopleIdAndProjectId(
-                peopleId.getValue(),
+    public ProjectLike loadBy(final MemberId memberId, final ProjectId projectId) {
+        final ProjectLikeJpaEntity jpaEntity = repository.findByMemberIdAndProjectId(
+                memberId.getValue(),
                 projectId.getValue()
             )
             .orElseThrow(NotFoundLikeException::new);

--- a/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikePersistenceMapper.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/like/project/ProjectLikePersistenceMapper.java
@@ -9,7 +9,7 @@ import org.mapstruct.Mapping;
 public interface ProjectLikePersistenceMapper {
 
     @Mapping(source = "projectId", target = "projectId.value")
-    @Mapping(source = "peopleId", target = "peopleId.value")
+    @Mapping(source = "memberId", target = "memberId.value")
     ProjectLike mapToDomain(ProjectLikeJpaEntity projectLikeJpaEntity);
 
     @InheritInverseConfiguration

--- a/src/main/java/es/princip/getp/persistence/adapter/people/PeopleQueryAdapter.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/people/PeopleQueryAdapter.java
@@ -8,6 +8,7 @@ import es.princip.getp.api.controller.people.query.dto.people.DetailPeopleRespon
 import es.princip.getp.api.controller.people.query.dto.people.MyPeopleResponse;
 import es.princip.getp.api.controller.people.query.dto.people.PublicDetailPeopleResponse;
 import es.princip.getp.api.controller.people.query.dto.peopleProfile.DetailPeopleProfileResponse;
+import es.princip.getp.application.like.people.port.out.CheckPeopleLikePort;
 import es.princip.getp.application.like.people.port.out.CountPeopleLikePort;
 import es.princip.getp.application.people.port.out.FindMyPeoplePort;
 import es.princip.getp.application.people.port.out.FindPeoplePort;
@@ -38,11 +39,12 @@ import static java.util.stream.Collectors.toMap;
 @Repository
 @RequiredArgsConstructor
 // TODO: 조회 성능 개선 필요
-public class PeopleQueryAdapter extends QueryDslSupport implements FindPeoplePort, FindMyPeoplePort {
+class PeopleQueryAdapter extends QueryDslSupport implements FindPeoplePort, FindMyPeoplePort {
 
     private static final QPeopleJpaEntity people = QPeopleJpaEntity.peopleJpaEntity;
     private static final QMemberJpaEntity member = QMemberJpaEntity.memberJpaEntity;
 
+    private final CheckPeopleLikePort checkPeopleLikePort;
     private final CountPeopleLikePort countPeopleLikePort;
 
     private final PeopleQueryMapper mapper;
@@ -116,7 +118,7 @@ public class PeopleQueryAdapter extends QueryDslSupport implements FindPeoplePor
     }
 
     @Override
-    public DetailPeopleResponse findDetailBy(final PeopleId peopleId) {
+    public DetailPeopleResponse findDetailBy(final MemberId memberId, final PeopleId peopleId) {
         final PeopleProfileJpaVO profile = Optional.ofNullable(
                 queryFactory.select(people)
                     .from(people)
@@ -137,6 +139,7 @@ public class PeopleQueryAdapter extends QueryDslSupport implements FindPeoplePor
             memberAndPeople.get(people.peopleType),
             0,
             countPeopleLikePort.countBy(peopleId),
+            checkPeopleLikePort.existsBy(memberId, peopleId),
             mapper.mapToDetailPeopleProfileResponse(profile)
         );
     }

--- a/src/main/resources/db/migration/V2__alter_like_member_id.sql
+++ b/src/main/resources/db/migration/V2__alter_like_member_id.sql
@@ -1,0 +1,2 @@
+alter table people_like rename column client_id to member_id;
+alter table project_like rename column people_id to member_id;

--- a/src/test/java/es/princip/getp/api/controller/people/query/description/DetailPeopleResponseDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/people/query/description/DetailPeopleResponseDescription.java
@@ -17,6 +17,7 @@ public class DetailPeopleResponseDescription {
                 .attributes(key("format").value("TEAM, INDIVIDUAL")),
             getDescriptor("completedProjectsCount", "완수한 프로젝트 수"),
             getDescriptor("likesCount", "받은 좋아요 수"),
+            getDescriptor("liked", "좋아요 여부"),
             getDescriptor("profile.introduction", "소개"),
             getDescriptor("profile.activityArea", "활동 지역"),
             getDescriptor("profile.techStacks[]", "기술 스택"),

--- a/src/test/java/es/princip/getp/api/controller/people/query/description/PagedCardPeopleResponseDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/people/query/description/PagedCardPeopleResponseDescription.java
@@ -1,0 +1,25 @@
+package es.princip.getp.api.controller.people.query.description;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+import static es.princip.getp.api.docs.FieldDescriptorHelper.getDescriptor;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+
+public class PagedCardPeopleResponseDescription {
+
+    public static FieldDescriptor[] description() {
+        return new FieldDescriptor[] {
+            getDescriptor("content[].peopleId", "피플 ID"),
+            getDescriptor("content[].peopleType", "피플 유형")
+                .attributes(key("format").value("TEAM, INDIVIDUAL")),
+            getDescriptor("content[].nickname", "닉네임"),
+            getDescriptor("content[].profileImageUri", "프로필 이미지 URI"),
+            getDescriptor("content[].completedProjectsCount", "완수한 프로젝트 수"),
+            getDescriptor("content[].likesCount", "받은 좋아요 수"),
+            getDescriptor("content[].profile.introduction", "소개"),
+            getDescriptor("content[].profile.activityArea", "활동 지역"),
+            getDescriptor("content[].profile.hashtags[]", "해시태그")
+        };
+    }
+}

--- a/src/test/java/es/princip/getp/application/like/people/service/LikePeopleMockingUtil.java
+++ b/src/test/java/es/princip/getp/application/like/people/service/LikePeopleMockingUtil.java
@@ -1,0 +1,28 @@
+package es.princip.getp.application.like.people.service;
+
+import es.princip.getp.application.like.people.port.out.CheckPeopleLikePort;
+import es.princip.getp.domain.member.model.MemberId;
+import es.princip.getp.domain.people.model.PeopleId;
+
+import static org.mockito.BDDMockito.given;
+
+public class LikePeopleMockingUtil {
+
+    static void mockMemberNeverLikedPeople(
+        final CheckPeopleLikePort checkPeopleLikePort,
+        final MemberId memberId,
+        final PeopleId peopleId
+    ) {
+        given(checkPeopleLikePort.existsBy(memberId, peopleId))
+            .willReturn(false);
+    }
+
+    static void mockMemberAlreadyLikedPeople(
+         final CheckPeopleLikePort checkPeopleLikePort,
+         final MemberId memberId,
+         final PeopleId peopleId
+    ) {
+        given(checkPeopleLikePort.existsBy(memberId, peopleId))
+            .willReturn(true);
+    }
+}

--- a/src/test/java/es/princip/getp/application/like/people/service/UnlikePeopleServiceTest.java
+++ b/src/test/java/es/princip/getp/application/like/people/service/UnlikePeopleServiceTest.java
@@ -1,19 +1,15 @@
 package es.princip.getp.application.like.people.service;
 
-import es.princip.getp.application.client.port.out.LoadClientPort;
 import es.princip.getp.application.like.exception.NeverLikedException;
 import es.princip.getp.application.like.people.port.out.CheckPeopleLikePort;
 import es.princip.getp.application.like.people.port.out.DeletePeopleLikePort;
 import es.princip.getp.application.like.people.port.out.LoadPeopleLikePort;
 import es.princip.getp.application.people.port.out.LoadPeoplePort;
-import es.princip.getp.domain.client.model.Client;
-import es.princip.getp.domain.client.model.ClientId;
 import es.princip.getp.domain.like.people.model.PeopleLike;
 import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.People;
 import es.princip.getp.domain.people.model.PeopleId;
 import es.princip.getp.domain.people.model.PeopleType;
-import es.princip.getp.fixture.client.ClientFixture;
 import es.princip.getp.fixture.like.PeopleLikeFixture;
 import es.princip.getp.fixture.people.PeopleFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,43 +19,39 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static es.princip.getp.application.like.people.service.LikePeopleMockingUtil.mockMemberAlreadyLikedPeople;
+import static es.princip.getp.application.like.people.service.LikePeopleMockingUtil.mockMemberNeverLikedPeople;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class UnlikePeopleServiceTest {
 
     @Mock private LoadPeoplePort loadPeoplePort;
-    @Mock private LoadClientPort loadClientPort;
     @Mock private LoadPeopleLikePort loadPeopleLikePort;
     @Mock private CheckPeopleLikePort checkPeopleLikePort;
     @Mock private DeletePeopleLikePort deletePeopleLikePort;
     @InjectMocks private UnlikePeopleService likePeopleService;
 
-    private final ClientId clientId = new ClientId(1L);
     private final MemberId memberId = new MemberId(1L);
     private final PeopleId peopleId = new PeopleId(1L);
     
     private final People people = PeopleFixture.people(memberId, PeopleType.INDIVIDUAL);    
-    private final PeopleLike like = PeopleLikeFixture.peopleLike(clientId, peopleId);
+    private final PeopleLike like = PeopleLikeFixture.peopleLike(memberId, peopleId);
 
     @BeforeEach
     void setUp() {
         given(loadPeoplePort.loadBy(peopleId)).willReturn(people);
-        Client client = spy(ClientFixture.client(memberId));
-        doReturn(clientId).when(client).getId();
-        given(loadClientPort.loadBy(memberId)).willReturn(client);
     }
 
     @Test
     void 의뢰자는_피플에_눌렀던_좋아요를_취소할_수_있다() {
-        given(checkPeopleLikePort.existsBy(clientId, peopleId))
-            .willReturn(true);
-        given(loadPeopleLikePort.loadBy(clientId, peopleId))
+        mockMemberAlreadyLikedPeople(checkPeopleLikePort, memberId, peopleId);
+        given(loadPeopleLikePort.loadBy(memberId, peopleId))
             .willReturn(like);
 
-        
         likePeopleService.unlike(memberId, peopleId);
 
         verify(deletePeopleLikePort, times(1)).delete(like);
@@ -67,8 +59,7 @@ class UnlikePeopleServiceTest {
 
     @Test
     void 의뢰자는_좋아요를_누른적이_없는_피플에_좋아요를_취소할_수_없다() {
-        given(checkPeopleLikePort.existsBy(clientId, peopleId))
-            .willReturn(false);
+        mockMemberNeverLikedPeople(checkPeopleLikePort, memberId, peopleId);
 
         assertThatThrownBy(() -> likePeopleService.unlike(memberId, peopleId))
             .isInstanceOf(NeverLikedException.class);

--- a/src/test/java/es/princip/getp/application/like/project/service/LikeProjectMockingUtil.java
+++ b/src/test/java/es/princip/getp/application/like/project/service/LikeProjectMockingUtil.java
@@ -1,0 +1,28 @@
+package es.princip.getp.application.like.project.service;
+
+import es.princip.getp.application.like.project.port.out.CheckProjectLikePort;
+import es.princip.getp.domain.member.model.MemberId;
+import es.princip.getp.domain.project.commission.model.ProjectId;
+
+import static org.mockito.BDDMockito.given;
+
+public class LikeProjectMockingUtil {
+
+    static void mockMemberNeverLikedProject(
+        final CheckProjectLikePort checkProjectLikePort,
+        final MemberId memberId,
+        final ProjectId projectId
+    ) {
+        given(checkProjectLikePort.existsBy(memberId, projectId))
+            .willReturn(false);
+    }
+
+    static void mockMemberAlreadyLikedProject(
+         final CheckProjectLikePort checkProjectLikePort,
+         final MemberId memberId,
+         final ProjectId projectId
+    ) {
+        given(checkProjectLikePort.existsBy(memberId, projectId))
+            .willReturn(true);
+    }
+}

--- a/src/test/java/es/princip/getp/application/like/project/service/LikeProjectServiceTest.java
+++ b/src/test/java/es/princip/getp/application/like/project/service/LikeProjectServiceTest.java
@@ -3,17 +3,12 @@ package es.princip.getp.application.like.project.service;
 import es.princip.getp.application.like.exception.AlreadyLikedException;
 import es.princip.getp.application.like.project.port.out.CheckProjectLikePort;
 import es.princip.getp.application.like.project.port.out.SaveProjectLikePort;
-import es.princip.getp.application.people.port.out.LoadPeoplePort;
 import es.princip.getp.application.project.commission.port.out.LoadProjectPort;
 import es.princip.getp.domain.client.model.ClientId;
 import es.princip.getp.domain.member.model.MemberId;
-import es.princip.getp.domain.people.model.People;
-import es.princip.getp.domain.people.model.PeopleId;
-import es.princip.getp.domain.people.model.PeopleType;
 import es.princip.getp.domain.project.commission.model.Project;
 import es.princip.getp.domain.project.commission.model.ProjectId;
 import es.princip.getp.domain.project.commission.model.ProjectStatus;
-import es.princip.getp.fixture.people.PeopleFixture;
 import es.princip.getp.fixture.project.ProjectFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,22 +17,23 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static es.princip.getp.application.like.project.service.LikeProjectMockingUtil.mockMemberAlreadyLikedProject;
+import static es.princip.getp.application.like.project.service.LikeProjectMockingUtil.mockMemberNeverLikedProject;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class LikeProjectServiceTest {
 
-    @Mock private LoadPeoplePort loadPeoplePort;
     @Mock private LoadProjectPort loadProjectPort;
     @Mock private CheckProjectLikePort checkProjectLikePort;
     @Mock private SaveProjectLikePort saveProjectLikePort;
     @InjectMocks private LikeProjectService likeProjectService;
 
     private final MemberId memberId = new MemberId(1L);
-    private final PeopleId peopleId = new PeopleId(1L);
     private final ClientId clientId = new ClientId(1L);
     private final ProjectId projectId = new ProjectId(1L);
     private final Project project = ProjectFixture.project(clientId, ProjectStatus.APPLYING);
@@ -45,29 +41,24 @@ public class LikeProjectServiceTest {
     @BeforeEach
     void setUp() {
         given(loadProjectPort.loadBy(projectId)).willReturn(project);
-        final People people = spy(PeopleFixture.people(memberId, PeopleType.INDIVIDUAL));
-        doReturn(peopleId).when(people).getId();
-        given(loadPeoplePort.loadBy(memberId)).willReturn(people);
     }
 
     @Test
     void 피플은_프로젝트에_좋아요를_누를_수_있다() {
-        given(checkProjectLikePort.existsBy(peopleId, projectId))
-            .willReturn(false);
+        mockMemberNeverLikedProject(checkProjectLikePort, memberId, projectId);
 
         likeProjectService.like(memberId, projectId);
 
         verify(saveProjectLikePort, times(1)).save(
             argThat(
-                arg -> arg.getPeopleId().equals(peopleId) && arg.getProjectId().equals(projectId)
+                arg -> arg.getMemberId().equals(memberId) && arg.getProjectId().equals(projectId)
             )
         );
     }
 
     @Test
     void 피플은_프로젝트에_좋아요를_중복으로_누를_수_없다() {
-        given(checkProjectLikePort.existsBy(peopleId, projectId))
-            .willReturn(true);
+        mockMemberAlreadyLikedProject(checkProjectLikePort, memberId, projectId);
 
         assertThatThrownBy(() -> likeProjectService.like(memberId, projectId))
             .isInstanceOf(AlreadyLikedException.class);

--- a/src/test/java/es/princip/getp/application/like/project/service/UnlikeProjectServiceTest.java
+++ b/src/test/java/es/princip/getp/application/like/project/service/UnlikeProjectServiceTest.java
@@ -4,19 +4,14 @@ import es.princip.getp.application.like.exception.NeverLikedException;
 import es.princip.getp.application.like.project.port.out.CheckProjectLikePort;
 import es.princip.getp.application.like.project.port.out.DeleteProjectLikePort;
 import es.princip.getp.application.like.project.port.out.LoadProjectLikePort;
-import es.princip.getp.application.people.port.out.LoadPeoplePort;
 import es.princip.getp.application.project.commission.port.out.LoadProjectPort;
 import es.princip.getp.domain.client.model.ClientId;
 import es.princip.getp.domain.like.project.model.ProjectLike;
 import es.princip.getp.domain.member.model.MemberId;
-import es.princip.getp.domain.people.model.People;
-import es.princip.getp.domain.people.model.PeopleId;
-import es.princip.getp.domain.people.model.PeopleType;
 import es.princip.getp.domain.project.commission.model.Project;
 import es.princip.getp.domain.project.commission.model.ProjectId;
 import es.princip.getp.domain.project.commission.model.ProjectStatus;
 import es.princip.getp.fixture.like.ProjectLikeFixture;
-import es.princip.getp.fixture.people.PeopleFixture;
 import es.princip.getp.fixture.project.ProjectFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,14 +20,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static es.princip.getp.application.like.project.service.LikeProjectMockingUtil.mockMemberAlreadyLikedProject;
+import static es.princip.getp.application.like.project.service.LikeProjectMockingUtil.mockMemberNeverLikedProject;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class UnlikeProjectServiceTest {
+class UnlikeProjectServiceTest {
 
-    @Mock private LoadPeoplePort loadPeoplePort;
     @Mock private LoadProjectPort loadProjectPort;
     @Mock private LoadProjectLikePort loadProjectLikePort;
     @Mock private CheckProjectLikePort checkProjectLikePort;
@@ -40,25 +37,21 @@ public class UnlikeProjectServiceTest {
     @InjectMocks private UnlikeProjectService unlikeProjectService;
 
     private final MemberId memberId = new MemberId(1L);
-    private final PeopleId peopleId = new PeopleId(1L);
     private final ClientId clientId = new ClientId(1L);
     private final ProjectId projectId = new ProjectId(1L);
+
     private final Project project = ProjectFixture.project(clientId, ProjectStatus.APPLYING);
-    private final ProjectLike like = ProjectLikeFixture.projectLike(peopleId, projectId);
+    private final ProjectLike like = ProjectLikeFixture.projectLike(memberId, projectId);
 
     @BeforeEach
     void setUp() {
         given(loadProjectPort.loadBy(projectId)).willReturn(project);
-        final People people = spy(PeopleFixture.people(memberId, PeopleType.INDIVIDUAL));
-        doReturn(peopleId).when(people).getId();
-        given(loadPeoplePort.loadBy(memberId)).willReturn(people);
     }
 
     @Test
     void 피플은_프로젝트에_눌렀던_좋아요를_취소할_수_있다() {
-        given(checkProjectLikePort.existsBy(peopleId, projectId))
-            .willReturn(true);
-        given(loadProjectLikePort.loadBy(peopleId, projectId))
+        mockMemberAlreadyLikedProject(checkProjectLikePort, memberId, projectId);
+        given(loadProjectLikePort.loadBy(memberId, projectId))
             .willReturn(like);
 
         unlikeProjectService.unlike(memberId, projectId);
@@ -68,8 +61,7 @@ public class UnlikeProjectServiceTest {
 
     @Test
     void 피플은_좋아요를_누른적이_없는_프로젝트에_좋아요를_취소할_수_없다() {
-        given(checkProjectLikePort.existsBy(peopleId, projectId))
-            .willReturn(false);
+        mockMemberNeverLikedProject(checkProjectLikePort, memberId, projectId);
 
         assertThatThrownBy(() -> unlikeProjectService.unlike(memberId, projectId))
             .isInstanceOf(NeverLikedException.class);

--- a/src/test/java/es/princip/getp/fixture/like/PeopleLikeFixture.java
+++ b/src/test/java/es/princip/getp/fixture/like/PeopleLikeFixture.java
@@ -1,13 +1,13 @@
 package es.princip.getp.fixture.like;
 
-import es.princip.getp.domain.client.model.ClientId;
 import es.princip.getp.domain.like.people.model.PeopleLike;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
 
 public class PeopleLikeFixture {
-    public static PeopleLike peopleLike(ClientId clientId, PeopleId peopleId) {
+    public static PeopleLike peopleLike(MemberId memberId, PeopleId peopleId) {
         return PeopleLike.builder()
-            .clientId(clientId)
+            .memberId(memberId)
             .peopleId(peopleId)
             .build();
     }

--- a/src/test/java/es/princip/getp/fixture/like/ProjectLikeFixture.java
+++ b/src/test/java/es/princip/getp/fixture/like/ProjectLikeFixture.java
@@ -1,13 +1,13 @@
 package es.princip.getp.fixture.like;
 
 import es.princip.getp.domain.like.project.model.ProjectLike;
-import es.princip.getp.domain.people.model.PeopleId;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.project.commission.model.ProjectId;
 
 public class ProjectLikeFixture {
-    public static ProjectLike projectLike(PeopleId peopleId, ProjectId projectId) {
+    public static ProjectLike projectLike(MemberId memberId, ProjectId projectId) {
         return ProjectLike.builder()
-            .peopleId(peopleId)
+            .memberId(memberId)
             .projectId(projectId)
             .build();
     }

--- a/src/test/java/es/princip/getp/persistence/adapter/like/people/CountPeopleLikeAdapterTest.java
+++ b/src/test/java/es/princip/getp/persistence/adapter/like/people/CountPeopleLikeAdapterTest.java
@@ -31,7 +31,7 @@ public class CountPeopleLikeAdapterTest extends PersistenceAdapterTest {
     @BeforeEach
     void setUp() {
         dataLoaders = List.of(
-            new PeopleLikeDataLoader(entityManager, peopleLikeMapper)
+            new PeopleLikeDataLoader(peopleLikeMapper, entityManager)
         );
         dataLoaders.forEach(dataLoader -> dataLoader.load(TEST_SIZE));
     }

--- a/src/test/java/es/princip/getp/persistence/adapter/like/people/PeopleLikeDataLoader.java
+++ b/src/test/java/es/princip/getp/persistence/adapter/like/people/PeopleLikeDataLoader.java
@@ -1,8 +1,7 @@
 package es.princip.getp.persistence.adapter.like.people;
 
-import es.princip.getp.domain.client.model.ClientId;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
-import es.princip.getp.fixture.like.PeopleLikeFixture;
 import es.princip.getp.persistence.support.DataLoader;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -11,21 +10,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.LongStream;
 
+import static es.princip.getp.fixture.like.PeopleLikeFixture.peopleLike;
+
 @RequiredArgsConstructor
 public class PeopleLikeDataLoader implements DataLoader {
 
-    private final EntityManager entityManager;
     private final PeopleLikePersistenceMapper mapper;
+    private final EntityManager entityManager;
 
     @Override
     public void load(final int size) {
         final List<PeopleLikeJpaEntity> likeList = new ArrayList<>();
-        LongStream.range(0, size).forEach(clientId ->
+        LongStream.rangeClosed(1, size).forEach(memberId ->
             LongStream.rangeClosed(1, size).forEach(peopleId ->
                 likeList.add(
                     mapper.mapToJpa(
-                        PeopleLikeFixture.peopleLike(
-                            new ClientId(1L),
+                        peopleLike(
+                            new MemberId(memberId),
                             new PeopleId(peopleId)
                         )
                     )

--- a/src/test/java/es/princip/getp/persistence/adapter/like/project/ProjectLikeDataLoader.java
+++ b/src/test/java/es/princip/getp/persistence/adapter/like/project/ProjectLikeDataLoader.java
@@ -1,8 +1,7 @@
 package es.princip.getp.persistence.adapter.like.project;
 
-import es.princip.getp.domain.people.model.PeopleId;
+import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.project.commission.model.ProjectId;
-import es.princip.getp.fixture.like.ProjectLikeFixture;
 import es.princip.getp.persistence.support.DataLoader;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.LongStream;
+
+import static es.princip.getp.fixture.like.ProjectLikeFixture.projectLike;
 
 @RequiredArgsConstructor
 public class ProjectLikeDataLoader implements DataLoader {
@@ -22,11 +23,14 @@ public class ProjectLikeDataLoader implements DataLoader {
     @Transactional
     public void load(final int size) {
         final List<ProjectLikeJpaEntity> projectLikeList = new ArrayList<>();
-        LongStream.rangeClosed(1, size).forEach(peopleId ->
+        LongStream.rangeClosed(1, size).forEach(memberId ->
             LongStream.rangeClosed(1, size).forEach(projectId ->
                 projectLikeList.add(
                     mapper.mapToJpa(
-                        ProjectLikeFixture.projectLike(new PeopleId(peopleId), new ProjectId(projectId))
+                        projectLike(
+                            new MemberId(memberId),
+                            new ProjectId(projectId)
+                        )
                     )
                 )
             )

--- a/src/test/java/es/princip/getp/persistence/adapter/people/PeopleQueryAdapterTest.java
+++ b/src/test/java/es/princip/getp/persistence/adapter/people/PeopleQueryAdapterTest.java
@@ -7,6 +7,8 @@ import es.princip.getp.api.controller.people.query.dto.people.PublicDetailPeople
 import es.princip.getp.api.controller.people.query.dto.peopleProfile.DetailPeopleProfileResponse;
 import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.people.model.PeopleId;
+import es.princip.getp.persistence.adapter.like.people.PeopleLikeDataLoader;
+import es.princip.getp.persistence.adapter.like.people.PeopleLikePersistenceMapper;
 import es.princip.getp.persistence.adapter.people.mapper.PeoplePersistenceMapper;
 import es.princip.getp.persistence.support.DataLoader;
 import es.princip.getp.persistence.support.PersistenceAdapterTest;
@@ -30,7 +32,8 @@ public class PeopleQueryAdapterTest extends PersistenceAdapterTest {
     private static final int PAGE_SIZE = 10;
 
     @PersistenceContext private EntityManager entityManager;
-    @Autowired private PeoplePersistenceMapper mapper;
+    @Autowired private PeopleLikePersistenceMapper peopleLikePersistenceMapper;
+    @Autowired private PeoplePersistenceMapper peoplePersistenceMapper;
     @Autowired private PeopleQueryAdapter adapter;
 
     private List<DataLoader> dataLoaders;
@@ -38,7 +41,8 @@ public class PeopleQueryAdapterTest extends PersistenceAdapterTest {
     @BeforeEach
     void setUp() {
         dataLoaders = List.of(
-            new PeopleDataLoader(mapper, entityManager)
+            new PeopleLikeDataLoader(peopleLikePersistenceMapper, entityManager),
+            new PeopleDataLoader(peoplePersistenceMapper, entityManager)
         );
         dataLoaders.forEach(dataLoader -> dataLoader.load(TEST_SIZE));
     }
@@ -59,10 +63,12 @@ public class PeopleQueryAdapterTest extends PersistenceAdapterTest {
 
     @Test
     void 피플_ID로_피플_상세_정보를_조회한다() {
+        final MemberId memberId = new MemberId(1L);
         final PeopleId peopleId = new PeopleId(1L);
-        final DetailPeopleResponse response = adapter.findDetailBy(peopleId);
+        final DetailPeopleResponse response = adapter.findDetailBy(memberId, peopleId);
 
         assertThat(response).isNotNull();
+        assertThat(response.liked()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## ✨ 구현한 기능
- 피플 상세 조회 DTO에 좋아요 여부 필드를 추가했습니다. 현재 회원 유형 중 의뢰자만 피플에 좋아요를 누를 수 있는데, 로그인 계정이 의뢰자인 경우 좋아요 여부를 피플 상세 조회에서 `liked` 필드를 통해 확인할 수 있습니다. 만약 로그인 계정이 의뢰자가 아니라면 `liked` 필드는 항상 `false` 입니다.

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 