### PR TITLE
GETP-275 feat: 의뢰자 정보 도메인 모델에서 계좌 필드 삭제

### DIFF
--- a/src/main/java/es/princip/getp/api/controller/client/command/dto/request/EditMyClientRequest.java
+++ b/src/main/java/es/princip/getp/api/controller/client/command/dto/request/EditMyClientRequest.java
@@ -2,7 +2,6 @@ package es.princip.getp.api.controller.client.command.dto.request;
 
 import es.princip.getp.application.client.command.EditClientCommand;
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.common.model.Email;
 import es.princip.getp.domain.common.model.EmailPattern;
 import es.princip.getp.domain.common.model.PhoneNumber;
@@ -18,8 +17,7 @@ public record EditMyClientRequest(
     @NotBlank String nickname,
     @NotNull @EmailPattern String email,
     @NotNull @PhoneNumberPattern String phoneNumber,
-    @NotNull @Valid Address address,
-    @NotNull @Valid BankAccount bankAccount
+    @NotNull @Valid Address address
 ) {
 
     public EditClientCommand toCommand(final MemberId memberId) {
@@ -28,8 +26,7 @@ public record EditMyClientRequest(
             Nickname.from(nickname()),
             Email.from(email()),
             PhoneNumber.from(phoneNumber()),
-            address,
-            bankAccount
+            address
         );
     }
 }

--- a/src/main/java/es/princip/getp/api/controller/client/command/dto/request/EditMyClientRequest.java
+++ b/src/main/java/es/princip/getp/api/controller/client/command/dto/request/EditMyClientRequest.java
@@ -2,7 +2,7 @@ package es.princip.getp.api.controller.client.command.dto.request;
 
 import es.princip.getp.application.client.command.EditClientCommand;
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.client.model.BankAccount;
+import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.common.model.Email;
 import es.princip.getp.domain.common.model.EmailPattern;
 import es.princip.getp.domain.common.model.PhoneNumber;

--- a/src/main/java/es/princip/getp/api/controller/client/command/dto/request/RegisterMyClientRequest.java
+++ b/src/main/java/es/princip/getp/api/controller/client/command/dto/request/RegisterMyClientRequest.java
@@ -2,7 +2,6 @@ package es.princip.getp.api.controller.client.command.dto.request;
 
 import es.princip.getp.application.client.command.RegisterClientCommand;
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.common.model.Email;
 import es.princip.getp.domain.common.model.EmailPattern;
 import es.princip.getp.domain.common.model.PhoneNumber;
@@ -17,8 +16,7 @@ public record RegisterMyClientRequest(
     @NotBlank String nickname, // 필수
     @EmailPattern String email, // 선택, 미입력 시 회원 가입 시 작성한 이메일 주소가 기본값
     @NotNull @PhoneNumberPattern String phoneNumber, // 필수
-    @Valid Address address, // 선택
-    @Valid BankAccount bankAccount // 선택
+    @Valid Address address // 선택
 ) {
 
     public RegisterClientCommand toCommand(final Member member) {
@@ -27,8 +25,7 @@ public record RegisterMyClientRequest(
             Nickname.from(nickname()),
             email() == null ? null : Email.from(email()),
             PhoneNumber.from(phoneNumber()),
-            address,
-            bankAccount
+            address
         );
     }
 }

--- a/src/main/java/es/princip/getp/api/controller/client/command/dto/request/RegisterMyClientRequest.java
+++ b/src/main/java/es/princip/getp/api/controller/client/command/dto/request/RegisterMyClientRequest.java
@@ -2,7 +2,7 @@ package es.princip.getp.api.controller.client.command.dto.request;
 
 import es.princip.getp.application.client.command.RegisterClientCommand;
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.client.model.BankAccount;
+import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.common.model.Email;
 import es.princip.getp.domain.common.model.EmailPattern;
 import es.princip.getp.domain.common.model.PhoneNumber;

--- a/src/main/java/es/princip/getp/api/controller/client/query/dto/ClientResponse.java
+++ b/src/main/java/es/princip/getp/api/controller/client/query/dto/ClientResponse.java
@@ -1,7 +1,6 @@
 package es.princip.getp.api.controller.client.query.dto;
 
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.common.model.BankAccount;
 
 import java.time.LocalDateTime;
 
@@ -12,7 +11,6 @@ public record ClientResponse(
     String email,
     String profileImageUri,
     Address address,
-    BankAccount bankAccount,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {

--- a/src/main/java/es/princip/getp/api/controller/client/query/dto/ClientResponse.java
+++ b/src/main/java/es/princip/getp/api/controller/client/query/dto/ClientResponse.java
@@ -1,7 +1,7 @@
 package es.princip.getp.api.controller.client.query.dto;
 
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.client.model.BankAccount;
+import es.princip.getp.domain.common.model.BankAccount;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/es/princip/getp/application/client/command/EditClientCommand.java
+++ b/src/main/java/es/princip/getp/application/client/command/EditClientCommand.java
@@ -1,7 +1,7 @@
 package es.princip.getp.application.client.command;
 
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.client.model.BankAccount;
+import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.common.model.Email;
 import es.princip.getp.domain.common.model.PhoneNumber;
 import es.princip.getp.domain.member.model.MemberId;

--- a/src/main/java/es/princip/getp/application/client/command/EditClientCommand.java
+++ b/src/main/java/es/princip/getp/application/client/command/EditClientCommand.java
@@ -1,7 +1,6 @@
 package es.princip.getp.application.client.command;
 
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.common.model.Email;
 import es.princip.getp.domain.common.model.PhoneNumber;
 import es.princip.getp.domain.member.model.MemberId;
@@ -12,7 +11,6 @@ public record EditClientCommand(
     Nickname nickname,
     Email email, // 미입력 시 회원 가입 시 작성한 이메일 주소가 기본값
     PhoneNumber phoneNumber,
-    Address address,
-    BankAccount bankAccount
+    Address address
 ) {
 }

--- a/src/main/java/es/princip/getp/application/client/command/RegisterClientCommand.java
+++ b/src/main/java/es/princip/getp/application/client/command/RegisterClientCommand.java
@@ -1,7 +1,6 @@
 package es.princip.getp.application.client.command;
 
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.common.model.Email;
 import es.princip.getp.domain.common.model.PhoneNumber;
 import es.princip.getp.domain.member.model.Member;
@@ -12,7 +11,6 @@ public record RegisterClientCommand(
     Nickname nickname,
     Email email, // 미입력 시 회원 가입 시 작성한 이메일 주소가 기본값
     PhoneNumber phoneNumber,
-    Address address,
-    BankAccount bankAccount
+    Address address
 ) {
 }

--- a/src/main/java/es/princip/getp/application/client/command/RegisterClientCommand.java
+++ b/src/main/java/es/princip/getp/application/client/command/RegisterClientCommand.java
@@ -1,7 +1,7 @@
 package es.princip.getp.application.client.command;
 
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.client.model.BankAccount;
+import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.common.model.Email;
 import es.princip.getp.domain.common.model.PhoneNumber;
 import es.princip.getp.domain.member.model.Member;

--- a/src/main/java/es/princip/getp/application/client/service/EditClientService.java
+++ b/src/main/java/es/princip/getp/application/client/service/EditClientService.java
@@ -26,7 +26,7 @@ public class EditClientService implements EditClientUseCase {
     public void edit(EditClientCommand command) {
         editMemberUseCase.editMember(EditMemberCommand.from(command));
         final Client client = loadClientPort.loadBy(command.memberId());
-        client.edit(command.email(), command.address(), command.bankAccount());
+        client.edit(command.email(), command.address());
         updateClientPort.update(client);
     }
 }

--- a/src/main/java/es/princip/getp/application/client/service/RegisterClientService.java
+++ b/src/main/java/es/princip/getp/application/client/service/RegisterClientService.java
@@ -37,7 +37,6 @@ public class RegisterClientService implements RegisterClientUseCase {
         final Email email = command.email() == null ? member.getEmail() : command.email();
         final Client client = Client.builder()
             .email(email)
-            .bankAccount(command.bankAccount())
             .address(command.address())
             .memberId(member.getId())
             .build();

--- a/src/main/java/es/princip/getp/domain/client/model/Client.java
+++ b/src/main/java/es/princip/getp/domain/client/model/Client.java
@@ -1,5 +1,6 @@
 package es.princip.getp.domain.client.model;
 
+import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.common.model.Email;
 import es.princip.getp.domain.member.model.MemberId;
 import es.princip.getp.domain.support.BaseEntity;

--- a/src/main/java/es/princip/getp/domain/client/model/Client.java
+++ b/src/main/java/es/princip/getp/domain/client/model/Client.java
@@ -24,7 +24,6 @@ public class Client extends BaseEntity {
         final ClientId id,
         final Email email,
         final Address address,
-        final BankAccount bankAccount,
         final MemberId memberId,
         final LocalDateTime createdAt,
         final LocalDateTime updatedAt
@@ -34,7 +33,6 @@ public class Client extends BaseEntity {
         this.id = id;
         this.email = email;
         this.address = address;
-        this.bankAccount = bankAccount;
         this.memberId = memberId;
 
         validate();
@@ -54,16 +52,8 @@ public class Client extends BaseEntity {
         this.address = address;
     }
 
-    private void setBankAccount(final BankAccount bankAccount) {
-        if (bankAccount == null) {
-            throw new IllegalArgumentException();
-        }
-        this.bankAccount = bankAccount;
-    }
-
-    public void edit(final Email email, final Address address, final BankAccount bankAccount) {
+    public void edit(final Email email, final Address address) {
         setEmail(email);
         setAddress(address);
-        setBankAccount(bankAccount);
     }
 }

--- a/src/main/java/es/princip/getp/domain/common/model/BankAccount.java
+++ b/src/main/java/es/princip/getp/domain/common/model/BankAccount.java
@@ -1,4 +1,4 @@
-package es.princip.getp.domain.client.model;
+package es.princip.getp.domain.common.model;
 
 import es.princip.getp.domain.support.BaseModel;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/es/princip/getp/persistence/adapter/client/ClientPersistenceMapper.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/client/ClientPersistenceMapper.java
@@ -1,8 +1,9 @@
 package es.princip.getp.persistence.adapter.client;
 
 import es.princip.getp.domain.client.model.Address;
-import es.princip.getp.domain.client.model.BankAccount;
 import es.princip.getp.domain.client.model.Client;
+import es.princip.getp.domain.common.model.BankAccount;
+
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/src/main/java/es/princip/getp/persistence/adapter/client/ClientQueryDslQuery.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/client/ClientQueryDslQuery.java
@@ -34,7 +34,6 @@ class ClientQueryDslQuery extends QueryDslSupport implements ClientQuery {
             result.get(client.email),
             result.get(member.profileImage),
             mapper.mapToDomain(result.get(client.address)),
-            mapper.mapToDomain(result.get(client.bankAccount)),
             result.get(client.createdAt),
             result.get(client.updatedAt)
         );
@@ -49,7 +48,6 @@ class ClientQueryDslQuery extends QueryDslSupport implements ClientQuery {
                 client.email,
                 member.profileImage,
                 client.address,
-                client.bankAccount,
                 client.createdAt,
                 client.updatedAt
             )
@@ -70,7 +68,6 @@ class ClientQueryDslQuery extends QueryDslSupport implements ClientQuery {
                 client.email,
                 member.profileImage,
                 client.address,
-                client.bankAccount,
                 client.createdAt,
                 client.updatedAt
             )

--- a/src/test/java/es/princip/getp/api/controller/client/command/MyClientControllerTest.java
+++ b/src/test/java/es/princip/getp/api/controller/client/command/MyClientControllerTest.java
@@ -24,7 +24,6 @@ import static es.princip.getp.api.docs.FieldDescriptorHelper.getDescriptor;
 import static es.princip.getp.api.docs.HeaderDescriptorHelper.authorizationHeaderDescriptor;
 import static es.princip.getp.api.docs.PayloadDocumentationHelper.responseFields;
 import static es.princip.getp.fixture.client.AddressFixture.address;
-import static es.princip.getp.fixture.client.BankAccountFixture.bankAccount;
 import static es.princip.getp.fixture.common.EmailFixture.EMAIL;
 import static es.princip.getp.fixture.member.NicknameFixture.NICKNAME;
 import static es.princip.getp.fixture.member.PhoneNumberFixture.PHONE_NUMBER;
@@ -53,8 +52,7 @@ class MyClientControllerTest extends ControllerTest {
             NICKNAME,
             EMAIL,
             PHONE_NUMBER,
-            address(),
-            bankAccount()
+            address()
         );
         final ClientId clientId = new ClientId(1L);
 
@@ -95,8 +93,7 @@ class MyClientControllerTest extends ControllerTest {
             NICKNAME,
             EMAIL,
             PHONE_NUMBER,
-            address(),
-            bankAccount()
+            address()
         );
 
         private ResultActions perform() throws Exception {

--- a/src/test/java/es/princip/getp/api/controller/client/command/description/BankAccountDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/client/command/description/BankAccountDescription.java
@@ -1,7 +1,8 @@
 package es.princip.getp.api.controller.client.command.description;
 
-import es.princip.getp.domain.client.model.BankAccount;
 import org.springframework.restdocs.payload.FieldDescriptor;
+
+import es.princip.getp.domain.common.model.BankAccount;
 
 import static es.princip.getp.api.docs.FieldDescriptorHelper.getDescriptor;
 

--- a/src/test/java/es/princip/getp/api/controller/client/command/description/EditMyClientRequestDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/client/command/description/EditMyClientRequestDescription.java
@@ -18,7 +18,6 @@ public class EditMyClientRequestDescription {
             getDescriptor("phoneNumber", "전화번호", clazz)
         ));
         descriptions.addAll(List.of(AddressDescription.description()));
-        descriptions.addAll(List.of(BankAccountDescription.description()));
         return descriptions.toArray(new FieldDescriptor[0]);
     }
 }

--- a/src/test/java/es/princip/getp/api/controller/client/command/description/RegisterMyClientRequestDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/client/command/description/RegisterMyClientRequestDescription.java
@@ -18,7 +18,6 @@ public class RegisterMyClientRequestDescription {
             getDescriptor("phoneNumber", "전화번호", clazz)
         ));
         descriptions.addAll(List.of(AddressDescription.description()));
-        descriptions.addAll(List.of(BankAccountDescription.description()));
         return descriptions.toArray(new FieldDescriptor[0]);
     }
 }

--- a/src/test/java/es/princip/getp/api/controller/client/query/ClientQueryControllerTest.java
+++ b/src/test/java/es/princip/getp/api/controller/client/query/ClientQueryControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDateTime;
 
 import static es.princip.getp.fixture.client.AddressFixture.address;
-import static es.princip.getp.fixture.client.BankAccountFixture.bankAccount;
 import static es.princip.getp.fixture.common.EmailFixture.EMAIL;
 import static es.princip.getp.fixture.member.NicknameFixture.NICKNAME;
 import static es.princip.getp.fixture.member.PhoneNumberFixture.PHONE_NUMBER;
@@ -55,7 +54,6 @@ class ClientQueryControllerTest extends ControllerTest {
                 EMAIL,
                 profileImage(memberId).getUrl(),
                 address(),
-                bankAccount(),
                 now,
                 now
             );
@@ -78,7 +76,6 @@ class ClientQueryControllerTest extends ControllerTest {
                 EMAIL,
                 profileImage(memberId).getUrl(),
                 address(),
-                bankAccount(),
                 now,
                 now
             );

--- a/src/test/java/es/princip/getp/api/controller/client/query/MyClientQueryControllerTest.java
+++ b/src/test/java/es/princip/getp/api/controller/client/query/MyClientQueryControllerTest.java
@@ -18,7 +18,6 @@ import java.time.LocalDateTime;
 
 import static es.princip.getp.api.docs.HeaderDescriptorHelper.authorizationHeaderDescriptor;
 import static es.princip.getp.fixture.client.AddressFixture.address;
-import static es.princip.getp.fixture.client.BankAccountFixture.bankAccount;
 import static es.princip.getp.fixture.common.EmailFixture.EMAIL;
 import static es.princip.getp.fixture.member.NicknameFixture.NICKNAME;
 import static es.princip.getp.fixture.member.PhoneNumberFixture.PHONE_NUMBER;
@@ -46,7 +45,6 @@ class MyClientQueryControllerTest extends ControllerTest {
             EMAIL,
             profileImage(memberId).getUrl(),
             address(),
-            bankAccount(),
             now,
             now
         );

--- a/src/test/java/es/princip/getp/api/controller/client/query/description/ClientResponseDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/client/query/description/ClientResponseDescription.java
@@ -1,7 +1,6 @@
 package es.princip.getp.api.controller.client.query.description;
 
 import es.princip.getp.api.controller.client.command.description.AddressDescription;
-import es.princip.getp.api.controller.client.command.description.BankAccountDescription;
 import org.springframework.restdocs.payload.FieldDescriptor;
 
 import java.util.ArrayList;
@@ -22,7 +21,6 @@ public class ClientResponseDescription {
             getDescriptor("updatedAt", "최근 의뢰자 정보 수정 일시")
         ));
         descriptions.addAll(List.of(AddressDescription.description()));
-        descriptions.addAll(List.of(BankAccountDescription.description()));
         return descriptions.toArray(new FieldDescriptor[0]);
     }
 }

--- a/src/test/java/es/princip/getp/api/controller/common/description/BankAccountDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/common/description/BankAccountDescription.java
@@ -1,8 +1,7 @@
-package es.princip.getp.api.controller.client.command.description;
-
-import org.springframework.restdocs.payload.FieldDescriptor;
+package es.princip.getp.api.controller.common.description;
 
 import es.princip.getp.domain.common.model.BankAccount;
+import org.springframework.restdocs.payload.FieldDescriptor;
 
 import static es.princip.getp.api.docs.FieldDescriptorHelper.getDescriptor;
 

--- a/src/test/java/es/princip/getp/domain/client/model/BankAccountTest.java
+++ b/src/test/java/es/princip/getp/domain/client/model/BankAccountTest.java
@@ -1,5 +1,6 @@
 package es.princip.getp.domain.client.model;
 
+import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.support.NotValidDomainModelException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/es/princip/getp/domain/common/model/BankAccountTest.java
+++ b/src/test/java/es/princip/getp/domain/common/model/BankAccountTest.java
@@ -1,6 +1,5 @@
 package es.princip.getp.domain.common.model;
 
-import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.support.NotValidDomainModelException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/es/princip/getp/domain/common/model/BankAccountTest.java
+++ b/src/test/java/es/princip/getp/domain/common/model/BankAccountTest.java
@@ -1,4 +1,4 @@
-package es.princip.getp.domain.client.model;
+package es.princip.getp.domain.common.model;
 
 import es.princip.getp.domain.common.model.BankAccount;
 import es.princip.getp.domain.support.NotValidDomainModelException;

--- a/src/test/java/es/princip/getp/fixture/client/BankAccountFixture.java
+++ b/src/test/java/es/princip/getp/fixture/client/BankAccountFixture.java
@@ -1,6 +1,6 @@
 package es.princip.getp.fixture.client;
 
-import es.princip.getp.domain.client.model.BankAccount;
+import es.princip.getp.domain.common.model.BankAccount;
 
 public class BankAccountFixture {
 

--- a/src/test/java/es/princip/getp/fixture/client/ClientFixture.java
+++ b/src/test/java/es/princip/getp/fixture/client/ClientFixture.java
@@ -4,7 +4,6 @@ import es.princip.getp.domain.client.model.Client;
 import es.princip.getp.domain.member.model.MemberId;
 
 import static es.princip.getp.fixture.client.AddressFixture.address;
-import static es.princip.getp.fixture.client.BankAccountFixture.bankAccount;
 import static es.princip.getp.fixture.common.EmailFixture.email;
 
 public class ClientFixture {
@@ -14,7 +13,6 @@ public class ClientFixture {
             .memberId(memberId)
             .email(email())
             .address(address())
-            .bankAccount(bankAccount())
             .build();
     }
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- 의뢰자 정보 도메인 모델에서 계좌 필드 삭제

## 📢 논의하고 싶은 내용
- X

## 🎸 기타
- `BankAccountVO`는 나중에 관리 도메인에서 사용 예정이기 때문에, 삭제하지 않고 공통 모델로 이동하였습니다.