### PR TITLE
GETP-270 feat: 피플 닉네임으로 검색 기능 구현

### DIFF
--- a/src/main/java/es/princip/getp/application/people/command/PeopleSearchFilter.java
+++ b/src/main/java/es/princip/getp/application/people/command/PeopleSearchFilter.java
@@ -5,9 +5,11 @@ import lombok.Getter;
 @Getter
 public class PeopleSearchFilter {
 
+    private final String keyword;
     private final boolean liked;
 
-    public PeopleSearchFilter(final String liked) {
+    public PeopleSearchFilter(final String keyword, final String liked) {
+        this.keyword = keyword;
         this.liked = Boolean.parseBoolean(liked);
     }
 }

--- a/src/main/java/es/princip/getp/persistence/adapter/people/FindPeopleAdapter.java
+++ b/src/main/java/es/princip/getp/persistence/adapter/people/FindPeopleAdapter.java
@@ -23,6 +23,7 @@ import es.princip.getp.persistence.adapter.people.model.PeopleProfileJpaVO;
 import es.princip.getp.persistence.adapter.people.model.QPeopleJpaEntity;
 import es.princip.getp.persistence.support.QueryDslSupport;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -96,6 +97,10 @@ class FindPeopleAdapter extends QueryDslSupport implements FindPeoplePort {
             selectFrom.join(like).on(people.id.eq(like.peopleId))
                 .join(member).on(like.memberId.eq(member.id))
                 .where(memberIdEq(memberId));
+        }
+        if (!StringUtils.isAllBlank(filter.getKeyword())) {
+            selectFrom.join(member).on(people.memberId.eq(member.id))
+                .where(member.nickname.startsWith(filter.getKeyword()));
         }
         selectFrom.where(people.profile.isNotNull());
         return selectFrom;

--- a/src/test/java/es/princip/getp/api/controller/people/query/description/GetCardPeoplePageQueryParametersDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/people/query/description/GetCardPeoplePageQueryParametersDescription.java
@@ -23,6 +23,9 @@ public class GetCardPeoplePageQueryParametersDescription {
                 .optional()
                 .attributes(key("default").value("null"))
                 .attributes(key("permission").value(MemberType.ROLE_CLIENT)),
+            parameterWithName("keyword").description("피플 닉네임으로 검색하기. 닉네임이 해당 키워드로 시작하는 피플을 검색해요.")
+                .optional()
+                .attributes(key("default").value("null"))
         };
     }
 }

--- a/src/test/java/es/princip/getp/persistence/adapter/member/MemberDataLoader.java
+++ b/src/test/java/es/princip/getp/persistence/adapter/member/MemberDataLoader.java
@@ -19,6 +19,7 @@ public class MemberDataLoader implements DataLoader {
         final List<MemberJpaEntity> memberList = LongStream.range(1, 1 + size)
             .mapToObj(i -> MemberJpaEntity.builder()
                 .email("test" + i + "@example.com")
+                .nickname("test" + i)
                 .password(PASSWORD)
                 .build())
             .toList();

--- a/src/test/java/es/princip/getp/persistence/adapter/people/FindPeopleAdapterTest.java
+++ b/src/test/java/es/princip/getp/persistence/adapter/people/FindPeopleAdapterTest.java
@@ -50,9 +50,9 @@ class FindPeopleAdapterTest extends PersistenceAdapterTest {
     }
 
     @Test
-    void 피플_카드_목록_페이지를_조회한다() {
+    void 피플_목록을_조회한다() {
         final Pageable pageable = PageRequest.of(0, PAGE_SIZE);
-        final PeopleSearchFilter filter = new PeopleSearchFilter("null");
+        final PeopleSearchFilter filter = new PeopleSearchFilter(null, null);
         final MemberId memberId = new MemberId(1L);
         final Page<CardPeopleResponse> response = adapter.findCardBy(pageable, filter, memberId);
 
@@ -61,15 +61,27 @@ class FindPeopleAdapterTest extends PersistenceAdapterTest {
     }
 
     @Test
-    void 좋아요한_피플_카드_목록_페이지를_조회한다() {
+    void 좋아요한_피플_목록을_조회한다() {
         final Pageable pageable = PageRequest.of(0, PAGE_SIZE);
-        final PeopleSearchFilter filter = new PeopleSearchFilter("true");
+        final PeopleSearchFilter filter = new PeopleSearchFilter(null, "true");
         final MemberId memberId = new MemberId(1L);
         final Page<CardPeopleResponse> response = adapter.findCardBy(pageable, filter, memberId);
 
         assertThat(response.getContent()).isNotEmpty();
         assertThat(response.getNumberOfElements()).isEqualTo(PAGE_SIZE);
         assertThat(response.getTotalElements()).isEqualTo(TEST_SIZE);
+    }
+
+    @Test
+    void 닉네임으로_피플을_검색한다() {
+        final Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+        final PeopleSearchFilter filter = new PeopleSearchFilter("test1", null);
+        final MemberId memberId = new MemberId(1L);
+        final Page<CardPeopleResponse> response = adapter.findCardBy(pageable, filter, memberId);
+
+        assertThat(response.getContent()).isNotEmpty();
+        assertThat(response.getNumberOfElements()).isEqualTo(PAGE_SIZE);
+        assertThat(response.getTotalElements()).isEqualTo(11L);
     }
 
     @Test


### PR DESCRIPTION
## ✨ 구현한 기능
- 피플 닉네임으로 검색 기능 구현

## 📢 논의하고 싶은 내용
- 현재 피플을 검색하는 기능이 피플 목록 조회 페이지와 프로젝트 지원 페이지에서 필요로 하고 있어요. 피플 목록 조회에서는 닉네임이 사용자가 검색한 키워드로 시작하는 피플을 검색하는 기능이 필요하고, 프로젝트 지원에서는 아직 정해지지 않았지만 팀원 검색을 위해 비슷한 기능을 필요로 해요. 다만, 프로젝트 지원에서 사용자가 검색한 키워드로 시작하는 피플을 모두 검색을 할지, 아니면 사용자가 검색한 키워드와 일치하는 피플만 검색을 할지 결정에 따라 API 구현 방법이 달라질 것 같아요. 또한 무한 스크롤 지원 여부에 대한 결정도 필요해요.

## 🎸 기타
- 