### PR TITLE
GETP-292 feat: 프로젝트 카테고리에 기타 필드 추가

### DIFF
--- a/src/main/java/es/princip/getp/domain/project/commission/model/ProjectCategory.java
+++ b/src/main/java/es/princip/getp/domain/project/commission/model/ProjectCategory.java
@@ -1,5 +1,5 @@
 package es.princip.getp.domain.project.commission.model;
 
 public enum ProjectCategory {
-    FRONTEND, BACKEND, WEB, PROGRAM
+    FRONTEND, BACKEND, WEB, PROGRAM, ETC
 }

--- a/src/main/resources/db/migration/V6__add_project_category_etc.sql
+++ b/src/main/resources/db/migration/V6__add_project_category_etc.sql
@@ -1,0 +1,1 @@
+alter table project modify category enum('BACKEND', 'FRONTEND', 'PROGRAM', 'WEB', 'ETC');

--- a/src/test/java/es/princip/getp/api/controller/project/command/description/CommissionProjectRequestDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/project/command/description/CommissionProjectRequestDescription.java
@@ -4,6 +4,7 @@ import es.princip.getp.api.controller.project.command.dto.request.CommissionProj
 import org.springframework.restdocs.payload.FieldDescriptor;
 
 import static es.princip.getp.api.docs.FieldDescriptorHelper.getDescriptor;
+import static org.springframework.restdocs.snippet.Attributes.key;
 
 public class CommissionProjectRequestDescription {
 
@@ -18,8 +19,10 @@ public class CommissionProjectRequestDescription {
             getDescriptor("estimatedDuration.startDate", "예상 작업 시작 기간", clazz),
             getDescriptor("estimatedDuration.endDate", "예상 작업 종료 기간", clazz),
             getDescriptor("description", "상세 설명", clazz),
-            getDescriptor("meetingType", "미팅 방식", clazz),
-            getDescriptor("category", "카테고리", clazz),
+            getDescriptor("meetingType", "미팅 방식", clazz)
+                .attributes(key("format").value("IN_PERSON, REMOTE")),
+            getDescriptor("category", "카테고리", clazz)
+                .attributes(key("format").value("BACKEND, FRONTEND, PROGRAM, WEB, ETC")),
             getDescriptor("attachmentFiles[]", "첨부 파일", clazz),
             getDescriptor("hashtags[]", "해시태그", clazz)
         };

--- a/src/test/java/es/princip/getp/api/controller/project/query/description/ProjectDetailResponseDescription.java
+++ b/src/test/java/es/princip/getp/api/controller/project/query/description/ProjectDetailResponseDescription.java
@@ -3,6 +3,7 @@ package es.princip.getp.api.controller.project.query.description;
 import org.springframework.restdocs.payload.FieldDescriptor;
 
 import static es.princip.getp.api.docs.FieldDescriptorHelper.getDescriptor;
+import static org.springframework.restdocs.snippet.Attributes.key;
 
 public class ProjectDetailResponseDescription {
 
@@ -18,8 +19,10 @@ public class ProjectDetailResponseDescription {
             getDescriptor("estimatedDuration.startDate", "예상 작업 시작 날짜"),
             getDescriptor("estimatedDuration.endDate", "예상 작업 종료 날짜"),
             getDescriptor("description", "상세 설명"),
-            getDescriptor("meetingType", "미팅 방식"),
-            getDescriptor("category", "카테고리"),
+            getDescriptor("meetingType", "미팅 방식")
+                .attributes(key("format").value("IN_PERSON, REMOTE")),
+            getDescriptor("category", "카테고리")
+                .attributes(key("format").value("BACKEND, FRONTEND, PROGRAM, WEB, ETC")),
             getDescriptor("status", "프로젝트 상태"),
             getDescriptor("attachmentFiles[]", "첨부 파일"),
             getDescriptor("hashtags[]", "해시태그"),


### PR DESCRIPTION
## ✨ 구현한 기능
- 프로젝트 카테고리에 기타 필드 추가

## 📢 논의하고 싶은 내용
- 현재 API 문서에서 필드 타입이 열거형인 경우, 설명이 부족한 상태에요. 이를 쉽고 편하게 해결하는 방법에 대한 고민이 필요해요.

## 🎸 기타
- 