### PR TITLE
GETP-325 feat: 프로젝트 지원 테이블 인덱스 설계를 통해 프로젝트 목록 조회 API 성능 약 2.35배 개선

### DIFF
--- a/get-p-persistence/src/main/resources/db/migration/V9__create_index_project_application.sql
+++ b/get-p-persistence/src/main/resources/db/migration/V9__create_index_project_application.sql
@@ -1,0 +1,5 @@
+create index ix_project_application_project_id_status
+on project_application(project_id, status);
+
+create index ix_team_project_application_teammate_project_application_id
+on team_project_application_teammate(project_application_id);


### PR DESCRIPTION
## ✨ 구현한 기능
- 프로젝트 지원 테이블 인덱스 설계를 통해 프로젝트 목록 조회 API 성능 약 2.35배 개선
- 프로젝트 목록 조회 API에 사용되는 쿼리를 분석하여 인덱스를 설계했어요.

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 