### PR TITLE
GETP-330 fix: 프로젝트 조회 시 의뢰자 정보 미등록한 경우 NPE 발생 오류 해결

### DIFF
--- a/get-p-application/src/main/java/es/princip/getp/application/project/commission/ProjectDetailResponseMosaicResolver.java
+++ b/get-p-application/src/main/java/es/princip/getp/application/project/commission/ProjectDetailResponseMosaicResolver.java
@@ -27,6 +27,9 @@ class ProjectDetailResponseMosaicResolver extends MosaicResolverSupport
     }
 
     private AddressResponse mosaicAddress(final AddressResponse address) {
+        if (address == null) {
+            return null;
+        }
         return new AddressResponse(
             mosaicMessage(address.zipcode()),
             mosaicMessage(address.street()),

--- a/get-p-application/src/main/java/es/princip/getp/application/project/commission/dto/response/ProjectClientResponse.java
+++ b/get-p-application/src/main/java/es/princip/getp/application/project/commission/dto/response/ProjectClientResponse.java
@@ -1,13 +1,13 @@
 package es.princip.getp.application.project.commission.dto.response;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
-
 import es.princip.getp.application.common.dto.response.AddressResponse;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
 public record ProjectClientResponse(
-    @JsonInclude(NON_NULL) Long clientId,
+    Long clientId,
     String nickname,
     AddressResponse address
 ) {


### PR DESCRIPTION
## ✨ 구현한 기능
- 의뢰자 주소는 Nullable인데, 비로그인 후 프로젝트 조회 시 의뢰자 주소를 모자이크하는 과정에서 NPE가 발생하는 오류를 해결했습니다.

## 📢 논의하고 싶은 내용
- Nullable한 필드를 Optional 처리 해줄지 고민이네요.

## 🎸 기타
- 